### PR TITLE
feat: compatibility with pydantic v2.x.y

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 
 dependencies = [
   "pyyaml ~= 6.0",
-  "pydantic ~= 1.10",
+  "pydantic >= 1.10",
 ]
 
 [tool.hatch.build]

--- a/src/openjd/model/_create_job.py
+++ b/src/openjd/model/_create_job.py
@@ -2,7 +2,12 @@
 
 from typing import TYPE_CHECKING, cast
 
-from pydantic import ValidationError
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from ._errors import DecodeValidationError
 from ._symbol_table import SymbolTable

--- a/src/openjd/model/_format_strings/_dyn_constrained_str.py
+++ b/src/openjd/model/_format_strings/_dyn_constrained_str.py
@@ -3,12 +3,22 @@
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional, Pattern, Union
 
-from pydantic.errors import AnyStrMaxLengthError, AnyStrMinLengthError, StrRegexError
-from pydantic.utils import update_not_none
-from pydantic.validators import strict_str_validator
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1.errors import AnyStrMaxLengthError, AnyStrMinLengthError, StrRegexError
+    from pydantic.v1.utils import update_not_none
+    from pydantic.v1.validators import strict_str_validator
 
-if TYPE_CHECKING:
-    from pydantic.typing import CallableGenerator
+    if TYPE_CHECKING:
+        from pydantic.v1.typing import CallableGenerator
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic.errors import AnyStrMaxLengthError, AnyStrMinLengthError, StrRegexError
+    from pydantic.utils import update_not_none
+    from pydantic.validators import strict_str_validator
+
+    if TYPE_CHECKING:
+        from pydantic.typing import CallableGenerator
 
 
 class DynamicConstrainedStr(str):

--- a/src/openjd/model/_format_strings/_format_string.py
+++ b/src/openjd/model/_format_strings/_format_string.py
@@ -10,7 +10,12 @@ from ._dyn_constrained_str import DynamicConstrainedStr
 from ._expression import InterpolationExpression
 
 if TYPE_CHECKING:
-    from pydantic.typing import CallableGenerator
+    try:
+        # Pydantic v1 embedded within v2, if it's installed.
+        from pydantic.v1.typing import CallableGenerator
+    except ImportError:  # pragma: no cover
+        # Default to pydantic v1
+        from pydantic.typing import CallableGenerator
 
 
 @dataclass

--- a/src/openjd/model/_internal/_create_job.py
+++ b/src/openjd/model/_internal/_create_job.py
@@ -2,8 +2,14 @@
 
 from typing import Any, Union
 
-from pydantic import ValidationError
-from pydantic.error_wrappers import ErrorWrapper
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+    from pydantic.v1.error_wrappers import ErrorWrapper
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
+    from pydantic.error_wrappers import ErrorWrapper
 
 from .._symbol_table import SymbolTable
 from .._format_strings import FormatString, FormatStringError

--- a/src/openjd/model/_internal/_model_variable_references.py
+++ b/src/openjd/model/_internal/_model_variable_references.py
@@ -5,7 +5,12 @@ __all__ = ["validate_model_template_variable_references"]
 from collections import defaultdict
 from typing import Any, cast
 
-from pydantic.error_wrappers import ErrorWrapper
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1.error_wrappers import ErrorWrapper
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic.error_wrappers import ErrorWrapper
 
 from .._format_strings import FormatString
 from .._types import OpenJDModel, ResolutionScope

--- a/src/openjd/model/_parse.py
+++ b/src/openjd/model/_parse.py
@@ -6,8 +6,16 @@ from enum import Enum
 from typing import Any, ClassVar, Type, TypeVar, cast
 
 import yaml
-from pydantic import BaseModel
-from pydantic import ValidationError as PydanticValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import BaseModel
+    from pydantic.v1 import ValidationError as PydanticValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import BaseModel
+    from pydantic import ValidationError as PydanticValidationError
+
 
 from ._errors import DecodeValidationError
 from ._types import JobTemplate, OpenJDModel, SchemaVersion

--- a/src/openjd/model/_types.py
+++ b/src/openjd/model/_types.py
@@ -8,7 +8,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Type
 
-from pydantic import BaseModel, Extra
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import BaseModel, Extra
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import BaseModel, Extra
 
 from ._symbol_table import SymbolTable
 

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -8,20 +8,39 @@ from enum import Enum
 from graphlib import CycleError, TopologicalSorter
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Type, Union, cast
 
-from pydantic import (
-    Field,
-    PositiveInt,
-    PositiveFloat,
-    StrictBool,
-    StrictInt,
-    ValidationError,
-    conint,
-    conlist,
-    constr,
-    root_validator,
-    validator,
-)
-from pydantic.error_wrappers import ErrorWrapper
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import (
+        Field,
+        PositiveInt,
+        PositiveFloat,
+        StrictBool,
+        StrictInt,
+        ValidationError,
+        conint,
+        conlist,
+        constr,
+        root_validator,
+        validator,
+    )
+    from pydantic.v1.error_wrappers import ErrorWrapper
+
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import (
+        Field,
+        PositiveInt,
+        PositiveFloat,
+        StrictBool,
+        StrictInt,
+        ValidationError,
+        conint,
+        conlist,
+        constr,
+        root_validator,
+        validator,
+    )
+    from pydantic.error_wrappers import ErrorWrapper
 
 from .._format_strings import FormatString
 from .._errors import ExpressionError, TokenError

--- a/test/openjd/model/_internal/test_create_job.py
+++ b/test/openjd/model/_internal/test_create_job.py
@@ -5,7 +5,13 @@ from decimal import Decimal
 from typing import Optional, Union, cast
 
 import pytest
-from pydantic import PositiveInt, ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import PositiveInt, ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import PositiveInt, ValidationError
 
 from openjd.model import SymbolTable
 from openjd.model._format_strings import FormatString

--- a/test/openjd/model/format_strings/test_dyn_constrained_str.py
+++ b/test/openjd/model/format_strings/test_dyn_constrained_str.py
@@ -3,7 +3,13 @@
 import re
 
 import pytest
-from pydantic import BaseModel, ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import BaseModel, ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import BaseModel, ValidationError
 
 from openjd.model._format_strings._dyn_constrained_str import DynamicConstrainedStr
 

--- a/test/openjd/model/v2023_09/test_action.py
+++ b/test/openjd/model/v2023_09/test_action.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import Action, EnvironmentActions, StepActions

--- a/test/openjd/model/v2023_09/test_embedded.py
+++ b/test/openjd/model/v2023_09/test_embedded.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import EmbeddedFileText

--- a/test/openjd/model/v2023_09/test_environments.py
+++ b/test/openjd/model/v2023_09/test_environments.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import Environment

--- a/test/openjd/model/v2023_09/test_job_parameters.py
+++ b/test/openjd/model/v2023_09/test_job_parameters.py
@@ -4,7 +4,13 @@ from decimal import Decimal
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_job_template.py
+++ b/test/openjd/model/v2023_09/test_job_template.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import JobTemplate

--- a/test/openjd/model/v2023_09/test_parameter_space.py
+++ b/test/openjd/model/v2023_09/test_parameter_space.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_scripts.py
+++ b/test/openjd/model/v2023_09/test_scripts.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import EnvironmentScript, StepScript

--- a/test/openjd/model/v2023_09/test_step_host_requirements.py
+++ b/test/openjd/model/v2023_09/test_step_host_requirements.py
@@ -4,7 +4,13 @@ from typing import Any
 import string
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_step_template.py
+++ b/test/openjd/model/v2023_09/test_step_template.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import StepTemplate

--- a/test/openjd/model/v2023_09/test_strings.py
+++ b/test/openjd/model/v2023_09/test_strings.py
@@ -4,7 +4,13 @@ from typing import Any
 import string
 
 import pytest
-from pydantic import BaseModel, ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import BaseModel, ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import BaseModel, ValidationError
 
 from openjd.model.v2023_09 import (
     AmountCapabilityName,

--- a/test/openjd/model/v2023_09/test_template_variables.py
+++ b/test/openjd/model/v2023_09/test_template_variables.py
@@ -3,7 +3,13 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic v1 embedded within v2, if it's installed.
+    from pydantic.v1 import ValidationError
+except ImportError:  # pragma: no cover
+    # Default to pydantic v1
+    from pydantic import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import JobTemplate


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Pydantic version 2 was released, and contains pydantic v1 as a submodule. This change allows this library to function with both major versions of Pydantic; it will automatically select the v1 submodule if v2 is available in the environment.

### What was the solution? (How)

Try to import the v1 module from pydantic v2, and fallback to pydantic v1 if that fails.

### What is the impact of this change?

Downstream consumers will be open to use Pydantic V2 at any time without needing to wait for this library to be updated.

### How was this change tested?

Using a `hatch shell`, I ran the test suite with both pydantic v2.3.0 and then again with v1.10.11 installed (via pip install --force).

### Was this change documented?

N/A

### Is this a breaking change?

No, quite the opposite.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*