### PR TITLE
chore: add missing checkout step to publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ jobs:
       CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
       CUSTOMER_REPOSITORY: ${{ secrets.CUSTOMER_REPOSITORY }}
     steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Publish workflow is missing the checkout step

### What was the solution? (How)
Add the step

### What is the impact of this change?
Fixes publishing

### How was this change tested?
Ran in a test CI

```
hatch run lint
hatch run test
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*