### PR TITLE
fix: make typed union disciminators function correctly

### DIFF
--- a/test/openjd/model/v2023_09/test_parameter_space.py
+++ b/test/openjd/model/v2023_09/test_parameter_space.py
@@ -455,6 +455,31 @@ class TestStepParameterSpaceDefinition:
             pytest.param(
                 {
                     "taskParameterDefinitions": [
+                        {"name": "foo", "range": [1]},
+                    ]
+                },
+                # If the discriminator ("type" field) is missing then we should only see a single
+                # error if the typed union discriminator is set up correctly. If it's not
+                # set up correctly, then we'll get one error for every type in the union.
+                1,
+                id="discriminator missing",
+            ),
+            pytest.param(
+                {
+                    "taskParameterDefinitions": [
+                        {"name": "foo", "type": "INT"},
+                    ]
+                },
+                # If we're missing a required field ("range") and the Union discriminator
+                # is set up correctly, then we should only see a single error for the field being
+                # missing in the specific Unioned type. If it's not set up correctly, then we'll
+                # see at least an error from each type in the Union.
+                1,
+                id="discriminator works",
+            ),
+            pytest.param(
+                {
+                    "taskParameterDefinitions": [
                         {"name": "foo", "type": "INT", "range": [1]},
                         {"name": "bar", "type": "INT", "range": [1]},
                     ],


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Model validation errors were much too verbose. If an error was made in a typed union, then you would see at least one error (often at least 2) for each type in the union when you should only see one for the specific union type that is applicable.

### What was the solution? (How)

This corrects two errors in the way that typed union disciminators were implemented in the model:
1. discriminator was spelled incorrectly ("desciminator") causing no discriminators to be active in the model; and
2. discriminators for collections of unions were defined incorrectly -- they need to be annotated on the element rather than applied to the collecttion field.

### What is the impact of this change?

Validation error messages are much easier to grok. The work's not done, but this is a step in the right direction.

### How was this change tested?

Unit tests, and manually via the cli `check` command.

As a sample, given:

```yaml
specificationVersion: 'jobtemplate-2023-09'
name: Test template
parameterDefinitions:
  - name: LineEditControl
    type: STRING
    userInterface:
      control: LINE__EDIT # LINE_EDIT
      label: Line Edit Control
      groupLabel: Text Controls
    description: "Unrestricted line of text!"
    default: Default line edit value.
  - name: MultiLineEditControl
    type: STRING
    userInterface:
      control: MULTILINE__EDIT # MULTILINE_EDIT
      label: Multi-line Edit Control
      groupLabel: Text Controls
    description: "Unrestricted text file"
    default: |
      This is a
      text file with
      multiple lines.
  - name: IntSpinner
    # type: INT
    userInterface:
      control: SPIN_BOX
      label: Default Int Spinner
      groupLabel: Int Spinners
    description: A default integer spinner.
    default: 42
steps:
- name: Step
  parameterSpace:
    taskParameterDefinitions:
    - name: p1
      # type: INT
      range: 1-10
    - name: p2
      type: STRING
      range:
      - "foo"
      - "bar"
    - name: p3
      type: FLOAT
      # range: 
    - name: p4
      type: INT
      # range: 
  script:
    embeddedFiles:
      - name: runScript
        type: TEXT
        runnable: true
        data: |
          #!/usr/bin/env bash

          echo 'LineEditControl value:'
          echo '{{Param.LineEditControl}}'

          echo 'ConstrainedLine value"'
          # For testing: This value doesn't exist
          echo '{{Param.ConstrainedLine}}'

          echo 'MultiLineEditControl value:'
          echo '{{Param.MultiLineEditControl}}'

    actions:
      onRun:
        command: '{{Task.File.runScript}}'
```

Before the change we get:
```bash
% openjd check ../test.yaml
ERROR: '../test.yaml' failed checks: 47 validation errors for JobTemplate
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 0 -> type
  field required (type=value_error.missing)
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 0 -> type
  field required (type=value_error.missing)
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 0 -> range
  value is not a valid list (type=type_error.list)
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 0 -> type
... and so on
```

After this change we get:
```bash
% openjd check ../test.yaml 
ERROR: '../test.yaml' failed checks: 6 validation errors for JobTemplate
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 0
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 2 -> FloatTaskParameterDefinition -> range
  field required (type=value_error.missing)
steps -> 0 -> parameterSpace -> taskParameterDefinitions -> 3 -> IntTaskParameterDefinition -> range
  field required (type=value_error.missing)
parameterDefinitions -> 0 -> JobStringParameterDefinition -> userInterface -> control
  value is not a valid enumeration member; permitted: 'LINE_EDIT', 'MULTILINE_EDIT', 'DROPDOWN_LIST', 'CHECK_BOX', 'HIDDEN' (type=type_error.enum; enum_values=[<StringUserInterfaceControl.LINE_EDIT: 'LINE_EDIT'>, <StringUserInterfaceControl.MULTILINE_EDIT: 'MULTILINE_EDIT'>, <StringUserInterfaceControl.DROPDOWN_LIST: 'DROPDOWN_LIST'>, <StringUserInterfaceControl.CHECK_BOX: 'CHECK_BOX'>, <StringUserInterfaceControl.HIDDEN: 'HIDDEN'>])
parameterDefinitions -> 1 -> JobStringParameterDefinition -> userInterface -> control
  value is not a valid enumeration member; permitted: 'LINE_EDIT', 'MULTILINE_EDIT', 'DROPDOWN_LIST', 'CHECK_BOX', 'HIDDEN' (type=type_error.enum; enum_values=[<StringUserInterfaceControl.LINE_EDIT: 'LINE_EDIT'>, <StringUserInterfaceControl.MULTILINE_EDIT: 'MULTILINE_EDIT'>, <StringUserInterfaceControl.DROPDOWN_LIST: 'DROPDOWN_LIST'>, <StringUserInterfaceControl.CHECK_BOX: 'CHECK_BOX'>, <StringUserInterfaceControl.HIDDEN: 'HIDDEN'>])
parameterDefinitions -> 2
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
```

### Was this change documented?

N/A

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*