### PR TITLE
chore(deps): updating hatch-vcs, pytest-timeout, and ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 requires-python = ">=3.9"
 
 dependencies = [
-  "pyyaml ~= 6.0",
+  "pyyaml == 6.0.*",
   "pydantic ~= 1.10",
 ]
 

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,2 +1,2 @@
-hatch >= 1.7.0, == 1.*
-hatch-vcs ~= 0.3.0
+hatch == 1.7.*
+hatch-vcs == 0.4.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,9 +1,9 @@
 coverage[toml] == 7.*
-pytest >= 7.4, == 7.*
-pytest-cov >= 4.1, == 4.*
-pytest-timeout >= 2.1, == 2.*
-pytest-xdist >= 3.3.1, == 3.*
+pytest == 7.4.*
+pytest-cov == 4.1.*
+pytest-timeout == 2.2.*
+pytest-xdist == 3.3.*
 types-PyYAML ~= 6.0
 black == 23.*
-ruff >= 0.0.286, == 0.0.*
+ruff == 0.1.*
 mypy == 1.6.*


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Several of the package's build & test dependencies are not on latest. There are dependabot PRs available for these, but this is faster than merging & rebasing those one-by-one.

### What was the solution? (How)

Updating build and test dependencies to their latest available versions: hatch-vcs to 0.4.*
pytest-timeout to 2.2.*
ruff to 0.1.*

Also adjusting the dep string for pytest, pytest-cov, pyyaml, and hatch to be clearer. These updates are not changing any versions.

### What is the impact of this change?

Updated build & test deps. No functional changes.

### How was this change tested?

Ran the usual CI tests.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*