### PR TITLE
feat: adds merge_job_parameter_definitions()

### DIFF
--- a/src/openjd/model/_parse.py
+++ b/src/openjd/model/_parse.py
@@ -144,7 +144,7 @@ def decode_job_template(*, template: dict[str, Any]) -> JobTemplate:
         )
     except ValueError:
         # Value of the schema version is not one we know.
-        values_allowed = ", ".join(str(s) for s in SchemaVersion.job_template_versions())
+        values_allowed = ", ".join(str(s.value) for s in SchemaVersion.job_template_versions())
         raise DecodeValidationError(
             (
                 f"Unknown template version: {document_version}. "
@@ -153,10 +153,10 @@ def decode_job_template(*, template: dict[str, Any]) -> JobTemplate:
         )
 
     if not SchemaVersion.is_job_template(schema_version):
-        values_allowed = ", ".join(str(s) for s in SchemaVersion.job_template_versions())
+        values_allowed = ", ".join(str(s.value) for s in SchemaVersion.job_template_versions())
         raise DecodeValidationError(
             (
-                f"Specification version '{str(schema_version)}' is not a Job Template version. "
+                f"Specification version '{document_version}' is not a Job Template version. "
                 f"Values allowed for 'specificationVersion' in Job Templates are: {values_allowed}"
             )
         )
@@ -202,15 +202,20 @@ def decode_environment_template(*, template: dict[str, Any]) -> EnvironmentTempl
         )
     except ValueError:
         # Value of the schema version is not one we know.
-        values_allowed = ", ".join(str(s) for s in SchemaVersion.environment_template_versions())
+        values_allowed = ", ".join(
+            str(s.value) for s in SchemaVersion.environment_template_versions()
+        )
         raise DecodeValidationError(
             f"Unknown template version: {document_version}. Allowed values are: {values_allowed}"
         )
 
     if not SchemaVersion.is_environment_template(schema_version):
-        values_allowed = ", ".join(str(s) for s in SchemaVersion.environment_template_versions())
+        values_allowed = ", ".join(
+            str(s.value) for s in SchemaVersion.environment_template_versions()
+        )
         raise DecodeValidationError(
-            f"Unknown template version: {document_version}. Allowed values are: {values_allowed}"
+            f"Specification version '{document_version}' is not an Environment Template version. "
+            f"Allowed values for 'specificationVersion' are: {values_allowed}"
         )
 
     if schema_version == SchemaVersion.ENVIRONMENT_v2023_09:

--- a/test/openjd/model/test_create_job.py
+++ b/test/openjd/model/test_create_job.py
@@ -3,16 +3,21 @@
 import pytest
 
 from openjd.model import (
+    DecodeValidationError,
     JobParameterInputValues,
     ParameterValue,
     ParameterValueType,
+    create_job,
     preprocess_job_parameters,
 )
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (
+    Environment as Environment_2023_09,
+    EnvironmentTemplate as EnvironmentTemplate_2023_09,
+    Job as Job_2023_09,
+    JobTemplate as JobTemplate_2023_09,
     JobParameterType as JobParameterType_2023_09,
 )
-from openjd.model.v2023_09 import JobTemplate as JobTemplate_2023_09
 
 minimal_job_template_2023_09 = _parse_model(
     model=JobTemplate_2023_09,
@@ -21,6 +26,10 @@ minimal_job_template_2023_09 = _parse_model(
         "name": "name",
         "steps": [{"name": "step", "script": {"actions": {"onRun": {"command": "do thing"}}}}],
     },
+)
+minimal_environment_2023_09 = _parse_model(
+    model=Environment_2023_09,
+    obj={"name": "env", "script": {"actions": {"onEnter": {"command": "do a thing"}}}},
 )
 
 
@@ -77,6 +86,39 @@ class TestPreprocessJobParameters_2023_09:  # noqa: N801
             in str(excinfo.value)
         )
 
+    def test_reports_extra_with_environments(self) -> None:
+        # Test that we get errors if we have extra job parameters defined.
+
+        # GIVEN
+        job_parameter_values: JobParameterInputValues = {
+            "ThisIsUnknown": "value",
+            "ThisIsKnown": "value",
+        }
+        job_template = JobTemplate_2023_09(
+            specificationVersion="jobtemplate-2023-09",
+            name="test",
+            steps=minimal_job_template_2023_09.steps,
+        )
+        env_template = EnvironmentTemplate_2023_09(
+            specificationVersion="environment-2023-09",
+            environment=minimal_environment_2023_09,
+            parameterDefinitions=[{"name": "ThisIsKnown", "type": "STRING"}],
+        )
+
+        # WHEN
+        with pytest.raises(ValueError) as excinfo:
+            preprocess_job_parameters(
+                job_template=job_template,
+                job_parameter_values=job_parameter_values,
+                environment_templates=[env_template],
+            )
+
+        # THEN
+        assert (
+            "Job parameter values provided for parameters that are not defined in the template: ThisIsUnknown"
+            in str(excinfo.value)
+        )
+
     def test_reports_missing(self) -> None:
         # Test that we get errors if we have missed defining job parameters
 
@@ -97,6 +139,37 @@ class TestPreprocessJobParameters_2023_09:  # noqa: N801
 
         # THEN
         assert "Values missing for required job parameters: ThisIsNotDefined" in str(excinfo.value)
+
+    def test_reports_missing_with_environments(self) -> None:
+        # Test that we get errors if we have missed defining job parameters
+
+        # GIVEN
+        job_parameter_values: JobParameterInputValues = dict()
+        job_template = JobTemplate_2023_09(
+            specificationVersion="jobtemplate-2023-09",
+            name="test",
+            parameterDefinitions=[{"name": "ThisIsNotDefined", "type": "STRING"}],
+            steps=minimal_job_template_2023_09.steps,
+        )
+        env_template = EnvironmentTemplate_2023_09(
+            specificationVersion="environment-2023-09",
+            environment=minimal_environment_2023_09,
+            parameterDefinitions=[{"name": "ThisIsAlsoMissing", "type": "STRING"}],
+        )
+
+        # WHEN
+        with pytest.raises(ValueError) as excinfo:
+            preprocess_job_parameters(
+                job_template=job_template,
+                job_parameter_values=job_parameter_values,
+                environment_templates=[env_template],
+            )
+
+        # THEN
+        assert (
+            "Values missing for required job parameters: ThisIsAlsoMissing, ThisIsNotDefined"
+            in str(excinfo.value)
+        )
 
     def test_collects_defaults(self) -> None:
         # Test that we add values for missing job parameters that have
@@ -119,6 +192,39 @@ class TestPreprocessJobParameters_2023_09:  # noqa: N801
         # THEN
         assert "Foo" in result
         assert result["Foo"] == ParameterValue(type=ParameterValueType.STRING, value="defaultValue")
+
+    def test_collects_defaults_with_environments(self) -> None:
+        # Test that we add values for missing job parameters that have
+        # defaults defined.
+
+        # GIVEN
+        job_parameter_values: JobParameterInputValues = {}
+        job_template = JobTemplate_2023_09(
+            specificationVersion="jobtemplate-2023-09",
+            name="test",
+            parameterDefinitions=[{"name": "Foo", "type": "STRING", "default": "defaultValue"}],
+            steps=minimal_job_template_2023_09.steps,
+        )
+        env_template = EnvironmentTemplate_2023_09(
+            specificationVersion="environment-2023-09",
+            environment=minimal_environment_2023_09,
+            parameterDefinitions=[{"name": "Bar", "type": "STRING", "default": "alsoDefaultValue"}],
+        )
+
+        # WHEN
+        result = preprocess_job_parameters(
+            job_template=job_template,
+            job_parameter_values=job_parameter_values,
+            environment_templates=[env_template],
+        )
+
+        # THEN
+        assert "Foo" in result
+        assert result["Foo"] == ParameterValue(type=ParameterValueType.STRING, value="defaultValue")
+        assert "Bar" in result
+        assert result["Bar"] == ParameterValue(
+            type=ParameterValueType.STRING, value="alsoDefaultValue"
+        )
 
     def test_ignores_defaults(self) -> None:
         # Test that we do not add values for job parameters that have
@@ -164,6 +270,36 @@ class TestPreprocessJobParameters_2023_09:  # noqa: N801
         assert "parameter Foo value must be at most 1 characters" in str(excinfo.value)
         assert len(str(excinfo.value).split("\n")) == 1
 
+    def test_checks_contraints_with_environments(self) -> None:
+        # Test that we see errors if a constraint is violated.
+
+        # GIVEN
+        job_parameter_values: JobParameterInputValues = {"Foo": "two", "Bar": "one"}
+        job_template = JobTemplate_2023_09(
+            specificationVersion="jobtemplate-2023-09",
+            name="test",
+            parameterDefinitions=[{"name": "Foo", "type": "STRING", "maxLength": 1}],
+            steps=minimal_job_template_2023_09.steps,
+        )
+        env_template = EnvironmentTemplate_2023_09(
+            specificationVersion="environment-2023-09",
+            environment=minimal_environment_2023_09,
+            parameterDefinitions=[{"name": "Bar", "type": "STRING", "minLength": 5}],
+        )
+
+        # WHEN
+        with pytest.raises(ValueError) as excinfo:
+            preprocess_job_parameters(
+                job_template=job_template,
+                job_parameter_values=job_parameter_values,
+                environment_templates=[env_template],
+            )
+
+        # THEN
+        assert "parameter Foo value must be at most 1 characters" in str(excinfo.value)
+        assert "parameter Bar value must be at least 5 characters" in str(excinfo.value)
+        assert len(str(excinfo.value).split("\n")) == 2
+
     def test_collects_multiple_errors(self) -> None:
         # Test that see all errors if we have multiple in the same run.
 
@@ -197,3 +333,124 @@ class TestPreprocessJobParameters_2023_09:  # noqa: N801
         )
         assert "Values missing for required job parameters: Buz" in str(excinfo.value)
         assert len(str(excinfo.value).split("\n")) == 3
+
+
+class TestCreateJob_2023_09:
+    def test_success(self) -> None:
+        # GIVEN
+        job_template = _parse_model(
+            model=JobTemplate_2023_09,
+            obj={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "Job",
+                "parameterDefinitions": [{"name": "Foo", "type": "INT", "minValue": 10}],
+                "steps": [
+                    {"name": "Step", "script": {"actions": {"onRun": {"command": "do something"}}}}
+                ],
+            },
+        )
+        parameter_values = {"Foo": ParameterValue(type=ParameterValueType.INT, value="20")}
+        expected = _parse_model(
+            model=Job_2023_09,
+            obj={
+                "name": "Job",
+                "parameters": {"Foo": {"type": "INT", "value": "20"}},
+                "steps": [
+                    {"name": "Step", "script": {"actions": {"onRun": {"command": "do something"}}}}
+                ],
+            },
+        )
+
+        # WHEN
+        result = create_job(job_template=job_template, job_parameter_values=parameter_values)
+
+        # THEN
+        assert result == expected
+
+    def test_with_preprocess_error_from_job_template(self) -> None:
+        # GIVEN
+        job_template = _parse_model(
+            model=JobTemplate_2023_09,
+            obj={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "Job",
+                "parameterDefinitions": [{"name": "Foo", "type": "INT", "minValue": 10}],
+                "steps": [
+                    {"name": "Step", "script": {"actions": {"onRun": {"command": "do something"}}}}
+                ],
+            },
+        )
+        parameter_values = {"Foo": ParameterValue(type=ParameterValueType.INT, value="5")}
+
+        # WHEN
+        with pytest.raises(DecodeValidationError) as excinfo:
+            create_job(job_template=job_template, job_parameter_values=parameter_values)
+
+        # THEN
+        assert "parameter Foo must be at least 10" in str(excinfo.value)
+
+    def test_with_preprocess_error_from_environment_template(self) -> None:
+        # GIVEN
+        job_template = _parse_model(
+            model=JobTemplate_2023_09,
+            obj={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "Job",
+                "parameterDefinitions": [{"name": "Foo", "type": "INT"}],
+                "steps": [
+                    {"name": "Step", "script": {"actions": {"onRun": {"command": "do something"}}}}
+                ],
+            },
+        )
+        env_template = _parse_model(
+            model=EnvironmentTemplate_2023_09,
+            obj={
+                "specificationVersion": "environment-2023-09",
+                "parameterDefinitions": [{"name": "Foo", "type": "INT", "minValue": 10}],
+                "environment": {
+                    "name": "Env",
+                    "script": {"actions": {"onEnter": {"command": "do something"}}},
+                },
+            },
+        )
+        parameter_values = {"Foo": ParameterValue(type=ParameterValueType.INT, value="5")}
+
+        # WHEN
+        with pytest.raises(DecodeValidationError) as excinfo:
+            create_job(
+                job_template=job_template,
+                job_parameter_values=parameter_values,
+                environment_templates=[env_template],
+            )
+
+        # THEN
+        assert "parameter Foo must be at least 10" in str(excinfo.value)
+
+    def test_fails_to_instantiate(self) -> None:
+        # GIVEN
+        job_template = _parse_model(
+            model=JobTemplate_2023_09,
+            obj={
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "{{Param.Foo}}",
+                "parameterDefinitions": [{"name": "Foo", "type": "STRING"}],
+                "steps": [
+                    {"name": "Step", "script": {"actions": {"onRun": {"command": "do something"}}}}
+                ],
+            },
+        )
+        parameter_values = {"Foo": ParameterValue(type=ParameterValueType.STRING, value="a" * 256)}
+
+        # WHEN
+        with pytest.raises(DecodeValidationError) as excinfo:
+            # This'll have an error when instantiating the Job due to the Job's name being too long.
+            create_job(
+                job_template=job_template,
+                job_parameter_values=parameter_values,
+            )
+
+        # THEN
+        assert (
+            "1 validation errors for JobTemplate\nname:\n\tensure this value has at most 128 characters"
+            in str(excinfo.value)
+        )

--- a/test/openjd/model/test_merge_job_parameters.py
+++ b/test/openjd/model/test_merge_job_parameters.py
@@ -1,21 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
+from typing import Any, Optional
 
 from openjd.model._merge_job_parameter import (
     SourcedParamDefinition,
+    merge_job_parameter_definitions,
     merge_job_parameter_definitions_for_one,
 )
 from openjd.model.v2023_09 import (
+    EnvironmentTemplate,
     JobStringParameterDefinition,
     JobPathParameterDefinition,
     JobIntParameterDefinition,
     JobFloatParameterDefinition,
+    JobTemplate,
 )
 from openjd.model import CompatibilityError, JobParameterDefinition, parse_model
 
 
-class Test_v2023_09:
+class TestMergeForOne_v2023_09:
     @pytest.mark.parametrize(
         "given, expected",
         [
@@ -436,3 +440,248 @@ class Test_v2023_09:
 
         # THEN
         assert expected in str(excinfo.value)
+
+
+BASIC_JOB_TEMPLATE_STEP_2023_09: dict[str, Any] = {
+    "name": "Test",
+    "script": {"actions": {"onRun": {"command": "foo"}}},
+}
+BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09: dict[str, Any] = {
+    "script": {"actions": {"onEnter": {"command": "bar"}}}
+}
+
+
+class TestMergeTemplates_v2023_09:
+    @pytest.mark.parametrize(
+        "given_job_template, given_envs, expected",
+        [
+            pytest.param(
+                parse_model(
+                    model=JobTemplate,
+                    obj={
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "Job",
+                        "parameterDefinitions": [
+                            {"name": "Foo", "type": "INT", "maxValue": 50},
+                            {"name": "Bar", "type": "STRING", "minLength": 1},
+                        ],
+                        "steps": [BASIC_JOB_TEMPLATE_STEP_2023_09],
+                    },
+                ),
+                None,  # No environments
+                [
+                    parse_model(
+                        model=JobIntParameterDefinition,
+                        obj={"name": "Foo", "type": "INT", "maxValue": 50},
+                    ),
+                    parse_model(
+                        model=JobStringParameterDefinition,
+                        obj={"name": "Bar", "type": "STRING", "minLength": 1},
+                    ),
+                ],
+                id="only job template",
+            ),
+            pytest.param(
+                None,  # No job template
+                [
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "minValue": 1},
+                                {"name": "Bar", "type": "STRING", "minLength": 5},
+                            ],
+                            "environment": {
+                                "name": "Env1",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "maxValue": 10},
+                                {"name": "Bar", "type": "STRING", "maxLength": 50},
+                            ],
+                            "environment": {
+                                "name": "Env2",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                ],
+                [
+                    parse_model(
+                        model=JobIntParameterDefinition,
+                        obj={"name": "Foo", "type": "INT", "minValue": 1, "maxValue": 10},
+                    ),
+                    parse_model(
+                        model=JobStringParameterDefinition,
+                        obj={"name": "Bar", "type": "STRING", "minLength": 5, "maxLength": 50},
+                    ),
+                ],
+                id="merging two environments",
+            ),
+            pytest.param(
+                parse_model(
+                    model=JobTemplate,
+                    obj={
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "Job",
+                        "parameterDefinitions": [
+                            {"name": "Foo", "type": "INT", "minValue": 5, "maxValue": 10},
+                            {
+                                "name": "Bar",
+                                "type": "STRING",
+                                "minLength": 20,
+                                "maxLength": 30,
+                                "default": "b" * 25,
+                            },
+                        ],
+                        "steps": [BASIC_JOB_TEMPLATE_STEP_2023_09],
+                    },
+                ),
+                [
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "minValue": 1, "default": 8},
+                                {"name": "Bar", "type": "STRING", "minLength": 5},
+                            ],
+                            "environment": {
+                                "name": "Env1",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "maxValue": 20},
+                                {
+                                    "name": "Bar",
+                                    "type": "STRING",
+                                    "maxLength": 50,
+                                    "default": "a" * 40,
+                                },
+                            ],
+                            "environment": {
+                                "name": "Env2",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                ],
+                [
+                    parse_model(
+                        model=JobIntParameterDefinition,
+                        obj={
+                            "name": "Foo",
+                            "type": "INT",
+                            "minValue": 5,
+                            "maxValue": 10,
+                            "default": 8,
+                        },
+                    ),
+                    parse_model(
+                        model=JobStringParameterDefinition,
+                        obj={
+                            "name": "Bar",
+                            "type": "STRING",
+                            "minLength": 20,
+                            "maxLength": 30,
+                            "default": "b" * 25,
+                        },
+                    ),
+                ],
+                id="merging environments and job template in correct order",
+            ),
+        ],
+    )
+    def test_success(
+        self,
+        given_job_template: Optional[JobTemplate],
+        given_envs: Optional[list[EnvironmentTemplate]],
+        expected: list[JobParameterDefinition],
+    ) -> None:
+        # WHEN
+        result = merge_job_parameter_definitions(
+            job_template=given_job_template, environment_templates=given_envs
+        )
+
+        # THEN
+        # note: convert to sets in the compare to be order-agnostic
+        assert set(result) == set(expected)
+
+    @pytest.mark.parametrize(
+        "given_job_template, given_envs, expected",
+        [
+            pytest.param(
+                parse_model(
+                    model=JobTemplate,
+                    obj={
+                        "specificationVersion": "jobtemplate-2023-09",
+                        "name": "Job",
+                        "parameterDefinitions": [
+                            # Only Bar is in conflict
+                            {"name": "Foo", "type": "INT", "minValue": 5},
+                            {"name": "Bar", "type": "STRING", "minLength": 5, "maxLength": 10},
+                        ],
+                        "steps": [BASIC_JOB_TEMPLATE_STEP_2023_09],
+                    },
+                ),
+                [
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "minValue": 10},
+                            ],
+                            "environment": {
+                                "name": "Env1",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                    parse_model(
+                        model=EnvironmentTemplate,
+                        obj={
+                            "specificationVersion": "environment-2023-09",
+                            "parameterDefinitions": [
+                                {"name": "Foo", "type": "INT", "minValue": 5},
+                                {"name": "Bar", "type": "STRING", "minLength": 20},
+                            ],
+                            "environment": {
+                                "name": "Env2",
+                                **BASIC_ENVIRONMENT_TEMPLATE_ACTION_2023_09,
+                            },
+                        },
+                    ),
+                ],
+                "The definitions for job parameter 'Bar' are in conflict:\n\tMerged constraint minLength (20) <= maxLength (10) is not satisfyable.",
+                id="two defs conflict",
+            ),
+        ],
+    )
+    def test_not_compatible(
+        self,
+        given_job_template: Optional[JobTemplate],
+        given_envs: Optional[list[EnvironmentTemplate]],
+        expected: str,
+    ):
+        # WHEN
+        with pytest.raises(CompatibilityError) as excinfo:
+            merge_job_parameter_definitions(
+                job_template=given_job_template, environment_templates=given_envs
+            )
+
+        # THEN
+        assert str(excinfo.value) == expected


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

When creating/running a Job, that Job is defined with a Job Template but can also include one or more externally-defined Environment Templates. The library does not currently support that.

### What was the solution? (How)

This adds support for including these Environment Templates when creating a job via create_job(), checking job parameters via preprocess_job_parameters(), and adds a new function that can be used just for checking compatibility (merge_job_parameter_definitions()).

### What is the impact of this change?

More complete featureset

### How was this change tested?

I added unit test coverage for the new code paths. I also noticed that `create_job()` didn't actually have any dedicated testing so I added tests for it.

### Was this change documented?

N/A

### Is this a breaking change?

No; not intentionally.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*