### PR TITLE
fix: crash when missing hostRequirement name

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1910,7 +1910,12 @@ class AttributeRequirementTemplate(OpenJDModel_v2023_09):
     def _validate_attribute_list(
         cls, v: AttributeCapabilityList, values: dict[str, Any], is_allof: bool
     ) -> None:
-        capability_name = values["name"].lower()
+        try:
+            capability_name = values["name"].lower()
+        except KeyError:
+            # Just return as though there is no error. The missing name field
+            # will be reported by the validation of 'name'
+            return
         standard_capability = STANDARD_ATTRIBUTE_CAPABILITIES.get(capability_name, {})
         if standard_capability:
             if is_allof and not standard_capability["multivalued"] and len(v) > 1:

--- a/test/openjd/model/v2023_09/test_step_host_requirements.py
+++ b/test/openjd/model/v2023_09/test_step_host_requirements.py
@@ -92,6 +92,16 @@ class TestAttributeRequirementTemplate:
     @pytest.mark.parametrize(
         "data,error_count",
         (
+            pytest.param(
+                {"allOf": ["a", "b"]},
+                1,
+                id="allOf missing name",
+            ),
+            pytest.param(
+                {"anyOf": ["a", "b"]},
+                1,
+                id="anyOf missing name",
+            ),
             # All the built-in attribute capabilities
             pytest.param(
                 {"name": "attr.worker.os.family"},
@@ -329,6 +339,16 @@ class TestAmountRequirementTemplate:
     @pytest.mark.parametrize(
         "data,error_count",
         (
+            pytest.param(
+                {"min": 0},
+                1,
+                id="min missing name",
+            ),
+            pytest.param(
+                {"max": 2},
+                1,
+                id="max missing name",
+            ),
             # All the built-in amount capabilities
             pytest.param(
                 {"name": "amount.worker.gpu.memory", "min": -2},


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

We discovered a crash when a job template is defining host requirements, but neglects to include the 'name' field in an AttributeHostRequirement. The crash was due to an assumption in the anyOf/allOf validator that the requirement has a name field. 

### What was the solution? (How)

Simply to enclose the crashing dictionary dereference within a try-except and to swallow the resulting exception. The missing name field is reported as a validation error by a different part of the validation logic.

### What is the impact of this change?

Users of the library will no longer experience a crash when their job template's host requirement is missing the name field.

### How was this change tested?

I added unit tests. They reproduced the error before the fix was applied.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*