### PR TITLE
fix: incorrect type for default in JobIntParameterDefinition

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1394,7 +1394,7 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
     minValue: Optional[int] = None  # noqa: N815
     maxValue: Optional[int] = None  # noqa: N815
     allowedValues: Optional[AllowedIntParameterList] = None  # noqa: N815
-    default: Optional[PositiveInt] = None
+    default: Optional[int] = None
 
     _template_variable_definitions = DefinesTemplateVariables(
         defines={

--- a/test/openjd/model/v2023_09/test_job_parameters.py
+++ b/test/openjd/model/v2023_09/test_job_parameters.py
@@ -1013,6 +1013,9 @@ class TestJobIntParameterDefinition:
             ),
             pytest.param({"name": "Foo", "type": "INT", "default": 1}, id="has default as int"),
             pytest.param(
+                {"name": "Foo", "type": "INT", "default": -1}, id="has default as negative int"
+            ),
+            pytest.param(
                 {"name": "Foo", "type": "INT", "default": "1"}, id="has default as string"
             ),
             pytest.param({"name": "Foo", "type": "INT", "minValue": 1}, id="has min value as int"),


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The 'default' property of a JobIntParameterDefinition was incorrectly constrained to be a positive integer (i.e. greater than 0). 

### What was the solution? (How)

This fixes the error by making the type of 'default' a plain int instead.

### What is the impact of this change?

Users will not get a validation error if they try to set a negative or zero value for the default of an integer-typed job parameter.

### How was this change tested?

I added a unit test for this case.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*