### PR TITLE
chore: enable python 3.12 in CI

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Python 3.12 was officially released some time ago, but our CIs don't test against it.

### What was the solution? (How)

Added 3.12 to the test matrix.

### What is the impact of this change?

It should help us find non-compatibilities with the in-support Python runtimes sooner.

### How was this change tested?

In the CI; if it's green, then it worked. :-)

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*