### PR TITLE
feat: Add topo_sorted() function to the StepDependencyGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,21 @@ job_template = decode_job_template(
             },
             {
                 "name": "Step2",
-                "dependencies": [ { "dependsOn": "Step1" }],
+                "dependencies": [ { "dependsOn": "Step1" }, { "dependsOn": "Step3" }],
                 "script": {
                     "actions": {
                         "onRun": { "command": "python", "args": [ "-c", "print('Step2')" ] }
                     }
                 }
-            }
+            },
+            {
+                "name": "Step3",
+                "script": {
+                    "actions": {
+                        "onRun": { "command": "echo", "args": [ "Step3" ] }
+                    }
+                }
+            },
         ]
     }
 )
@@ -200,8 +208,13 @@ for step in job.steps:
     if step_node.out_edges:
         name_list = ', '.join(edge.dependent.step.name for edge in step_node.out_edges)
         print(f"The following Steps depend upon '{step.name}': {name_list}")
+
+print(f"\nSteps in topological order: {[step.name for step in dependency_graph.topo_sorted()]}")
 # The following Steps depend upon 'Step1': Step2
-# Step 'Step2' depends upon: Step1
+# Step 'Step2' depends upon: Step1, Step3
+# The following Steps depend upon 'Step3': Step2
+
+# Steps in topological order: ['Step1', 'Step3', 'Step2']
 ```
 
 ### Working with a Step's Tasks

--- a/test/openjd/model/test_step_dependency_graph.py
+++ b/test/openjd/model/test_step_dependency_graph.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from typing import Any, Optional
+import random
+import pytest
 
 from openjd.model import (  # StepDependencyGraphNode,; ,
     StepDependencyGraph,
@@ -13,7 +15,7 @@ from openjd.model.v2023_09 import JobTemplate as JobTemplate_2023_09
 
 class TestStepDependencyGraph_2023_09:
     def create_step_template(
-        self, name: str, dependsOn: Optional[set[str]] = None
+        self, name: str, dependsOn: Optional[list[str]] = None
     ) -> dict[str, Any]:
         """A helper for generating step template data."""
         toreturn: dict[str, Any] = {
@@ -55,8 +57,8 @@ class TestStepDependencyGraph_2023_09:
             "specificationVersion": "jobtemplate-2023-09",
             "name": "Job",
             "steps": [
-                self.create_step_template("Foo", {"Buz"}),
-                self.create_step_template("Bar", {"Foo", "Buz"}),
+                self.create_step_template("Foo", ["Buz"]),
+                self.create_step_template("Bar", ["Foo", "Buz"]),
                 self.create_step_template("Buz"),
             ],
         }
@@ -112,3 +114,122 @@ class TestStepDependencyGraph_2023_09:
         assert edge2.origin.step.name == "Buz"
         assert edge1.dependent.step.name == "Foo" or edge2.dependent.step.name == "Foo"
         assert edge1.dependent.step.name == "Bar" or edge2.dependent.step.name == "Bar"
+
+    def test_topo_sort_no_deps_preserves_order(self) -> None:
+        # If there are no edges, the topological sort should leave the ordering unchanged
+        # GIVEN
+        template_data: dict[str, Any] = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Job",
+            "steps": [],
+        }
+        for _ in range(100):
+            # Randomly generate the step names to rule out name-based ordering
+            template_data["steps"].append(
+                self.create_step_template("".join(random.sample("abcdefghijklmnop", 10)))
+            )
+        job_template = parse_model(model=JobTemplate_2023_09, obj=template_data)
+        job = create_job(job_template=job_template, job_parameter_values=dict())
+        graph = StepDependencyGraph(job=job)
+
+        # WHEN
+        topo_sorted_steps = graph.topo_sorted()
+
+        # THEN
+        assert job.steps == topo_sorted_steps
+
+    def test_topo_sort_reverse_chain(self) -> None:
+        # A chain going from the last to the first step should reverse the order
+        # GIVEN
+        template_data = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Job",
+            "steps": [
+                self.create_step_template("S1", ["S2"]),
+                self.create_step_template("S2", ["S3"]),
+                self.create_step_template("S3", ["S4"]),
+                self.create_step_template("S4", ["S5"]),
+                self.create_step_template("S5", ["S6"]),
+                self.create_step_template("S6", ["S7"]),
+                self.create_step_template("S7"),
+            ],
+        }
+        job_template = parse_model(model=JobTemplate_2023_09, obj=template_data)
+        job = create_job(job_template=job_template, job_parameter_values=dict())
+        graph = StepDependencyGraph(job=job)
+
+        # WHEN
+        topo_sorted_steps = graph.topo_sorted()
+
+        # THEN
+        assert list(reversed(job.steps)) == topo_sorted_steps
+
+    @pytest.mark.parametrize(
+        "ordered_s1_deps",
+        [
+            pytest.param(["S2", "S3", "S5", "S6", "S7"], id="sorted"),
+            pytest.param(["S7", "S6", "S5", "S3", "S2"], id="reverse sorted"),
+            pytest.param(["S2", "S6", "S5", "S7", "S3"], id="random order"),
+        ],
+    )
+    def test_topo_sort_dep_order(self, ordered_s1_deps: list[str]) -> None:
+        # When steps are reordered, they stay stable according to the definition in the topo_sorted docstring
+        # GIVEN
+        template_data = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Job",
+            "steps": [
+                self.create_step_template("S1", ordered_s1_deps),
+                self.create_step_template("S2"),
+                self.create_step_template("S3"),
+                self.create_step_template("S4"),
+                self.create_step_template("S5"),
+                self.create_step_template("S6"),
+                self.create_step_template("S7"),
+            ],
+        }
+        job_template = parse_model(model=JobTemplate_2023_09, obj=template_data)
+        job = create_job(job_template=job_template, job_parameter_values=dict())
+        graph = StepDependencyGraph(job=job)
+
+        # WHEN
+        topo_sorted_steps = graph.topo_sorted()
+
+        # THEN
+        assert ["S2", "S3", "S5", "S6", "S7", "S1", "S4"] == [
+            step.name for step in topo_sorted_steps
+        ]
+
+    def test_topo_sort_cycle_error(self) -> None:
+        # A cycle raises an exception
+        # GIVEN
+        template_data = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Job",
+            "steps": [
+                self.create_step_template("S1", ["S2"]),
+                self.create_step_template("S2", ["S3"]),
+                self.create_step_template("S3", ["S4"]),
+                self.create_step_template("S4", ["S5"]),
+                self.create_step_template("S5", ["S6"]),
+                self.create_step_template("S6", ["S7"]),
+                self.create_step_template("S7"),
+            ],
+        }
+        job_template = parse_model(model=JobTemplate_2023_09, obj=template_data)
+        job = create_job(job_template=job_template, job_parameter_values=dict())
+        graph = StepDependencyGraph(job=job)
+        # By hand, poke into the graph and finish the cycle
+        node_S7 = graph.step_node(stepname="S7")
+        node_S1 = graph.step_node(stepname="S1")
+        edge = StepDependencyGraphStepToStepEdge(origin=node_S1, dependent=node_S7)
+        node_S7.in_edges.append(edge)
+        node_S1.out_edges.append(edge)
+
+        # WHEN
+        with pytest.raises(ValueError) as e:
+            graph.topo_sorted()
+
+        # THEN
+        assert "circular dependency was found" in str(e)
+        assert "S1 -> S2 -> S3 -> S4 -> S5 -> S6 -> S7 -> S1" in str(e)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Want to provide the steps of a job in a topological sorted order. The best experience will be when it is also a stable sort, so that the step ordering in the job template is preserved as much as possible. In testing, Python's graphlib.TopologicalSorter was found to not be stable.

        Example uses for this ordering:
        1. To run all the Steps of a job in serial order. In topological order, every
            Step will run after all its dependencies.
        2. To submit a job to a render farm, one step at a time. In topological order,
            all the dependencies of each Step will have already been submitted, so all
            the IDs needed to specify dependencies in the destination render farm are
            available.

### What was the solution? (How)

* Implement a stable topological sort as a member function of the graph.
* Modify the StepDependencyGraph example in README.md to have a graph that is reordered, and print the topo_sorted() output.
* Add unit tests validating the basic properties of the topo sort.

### What is the impact of this change?

Integrating OpenJD with render farms or in other contexts will be easier with the ability to easily get the steps in a stable topological order.

### How was this change tested?

Implemented unit tests of the toposort.

### Was this change documented?

Added to the example in README.md that shows using the step graph, to also output the topological sorted order.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*