### PR TITLE
feat: Extend IntRangeExpression and make it an external interface

### DIFF
--- a/src/openjd/model/__init__.py
+++ b/src/openjd/model/__init__.py
@@ -10,6 +10,7 @@ from ._errors import (
     TokenError,
     UnsupportedSchema,
 )
+from ._range_expr import IntRangeExpr
 from ._parse import (
     DocumentType,
     decode_template,
@@ -61,6 +62,7 @@ __all__ = (
     "EnvironmentTemplate",
     "ExpressionError",
     "FormatStringError",
+    "IntRangeExpr",
     "Job",
     "JobParameterDefinition",
     "JobParameterInputValues",

--- a/src/openjd/model/_internal/__init__.py
+++ b/src/openjd/model/_internal/__init__.py
@@ -9,8 +9,6 @@ from ._combination_expr import Parser as CombinationExpressionParser
 from ._combination_expr import ProductNode as CombinationExpressionProductNode
 from ._create_job import instantiate_model
 from ._model_variable_references import validate_model_template_variable_references
-from ._range_expr import IntRange, IntRangeExpression
-from ._range_expr import Parser as RangeExpressionParser
 
 __all__ = (
     "instantiate_model",
@@ -21,9 +19,6 @@ __all__ = (
     "CombinationExpressionNode",
     "CombinationExpressionParser",
     "CombinationExpressionProductNode",
-    "RangeExpressionParser",
-    "IntRangeExpression",
-    "IntRange",
 )
 
 T = TypeVar("T")

--- a/src/openjd/model/_step_param_space_iter.py
+++ b/src/openjd/model/_step_param_space_iter.py
@@ -15,9 +15,8 @@ from ._internal import (
     CombinationExpressionNode,
     CombinationExpressionParser,
     CombinationExpressionProductNode,
-    IntRangeExpression,
-    RangeExpressionParser,
 )
+from ._range_expr import IntRangeExpr
 from ._types import ParameterValue, ParameterValueType, StepParameterSpace, TaskParameterSet
 from .v2023_09 import (
     RangeExpressionTaskParameterDefinition as RangeExpressionTaskParameterDefinition_2023_09,
@@ -437,11 +436,11 @@ class RangeExpressionIdentifierNode(Node):
     name: str
     type: ParameterValueType
     range: str
-    range_expression: IntRangeExpression = field(init=False, repr=False, compare=False)
+    range_expression: IntRangeExpr = field(init=False, repr=False, compare=False)
     _len: int = field(init=False, repr=False, compare=False)
 
     def __post_init__(self):
-        self.range_expression = RangeExpressionParser().parse(self.range)
+        self.range_expression = IntRangeExpr.from_str(self.range)
         self._len = len(self.range_expression)
 
     def __len__(self) -> int:

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -32,10 +32,10 @@ from .._capabilities import (
 )
 from .._internal import (
     CombinationExpressionParser,
-    RangeExpressionParser,
     validate_model_template_variable_references,
     validate_unique_elements,
 )
+from .._range_expr import IntRangeExpr
 from .._types import (
     DefinesTemplateVariables,
     JobCreateAsMetadata,
@@ -487,7 +487,7 @@ class RangeExpressionTaskParameterDefinition(OpenJDModel_v2023_09):
         """At this point, the format expressions have been resolved
         and we can determine if it's a valid RangeExpression"""
         try:
-            RangeExpressionParser().parse(value)
+            IntRangeExpr.from_str(value)
         except Exception as e:
             raise ValueError(str(e))
 
@@ -577,7 +577,7 @@ class IntTaskParameterDefinition(OpenJDModel_v2023_09):
             # they've all been evaluated
             if len(value.expressions) == 0:
                 try:
-                    RangeExpressionParser().parse(value)
+                    IntRangeExpr.from_str(value)
                 except Exception as e:
                     raise ValueError(str(e))
         return value


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A common operation that code using the OpenJD models will need to do is work with range expression strings. These are the inputs of GUIs or CLI tools to specify the list of frames to render, and transforming to/from a string or a list can help provide useful functionality. The IntRangeExprsesion class provides a lot of the help, but is internal-only to the library, and lacks convenience functions to convert from list and string, and to convert back to a string.

### What was the solution? (How)

* Rename IntRangeExpression to the shorter IntRangeExpr, to reduce the verbosity and amount of typing when using it.
* Move the IntRangeExpr into the external model API.
* Add the IntRangeExpr.from_list that constructs the object from a list of integers or strings containing integers.
* Add the IntRangeExpr.from_str constructor function that calls the existing parser.
* Add IntRange.__str__ that converts the object back into a string int range expression.
* Change the model parser to use IntRangeExpr.from_str instead of calling the parser implementation directly.
* Add tests of the new functions.

### What is the impact of this change?

Code that uses openjd-model-for-python can use the IntRangeExpr class to work with integer range expressions.

### How was this change tested?

Added unit tests for the new functionality, and used it to simplify integration code.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*