### PR TITLE
chore(release): use correct author email and fix PublishToRepository job

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: ConfigureGit
         run: |
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
       - name: MergePushRelease

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -70,7 +70,7 @@ jobs:
           # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
           TAG="$NEXT_SEMVER"
 
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
           git tag -a $TAG -m "Release $TAG"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The `Release: Publish` workflow is failing because the expected author in the workflow file is incorrect
- I found a bug in `PublishToRepository` that is not being surfaced due to the defaults for `actions/checkout` related to the ref it was checking out not existing, so it defaults to the ref that started the workflow, which is coincidentally the ref we want to checkout (the tip of `release` with the latest release tag).
    - If the release branch gets new commits while there's an ongoing release, this will result in either a `post#` or another version release being made (depending on if the tip of `release` is tagged).

### What was the solution? (How)
- Update author in workflow
- Add concurrency lock to the release workflows and checkout `release` in `PublishToRepository`. This means there will only be one `Release: Publish` or `Release: Bump` workflow allowed to happen at a time, reducing risk of accidentally pushing to the `release` branch while a release is happening

### What is the impact of this change?
Release workflow works and is more robust

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*