### PR TITLE
chore(release): fix auth token for codeartifact

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -148,6 +148,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
 Resolving the hatch environment currently requires a codeartifact auth token be defined in the environment. This was being set in a previous version of the release process, but was accidentally missed in the new version. The end-effect was a failed attempt at a release: https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/7831825466/job/21369076085

### What was the solution? (How)

Copied the missing auth token definition from a previous version of the release: https://github.com/OpenJobDescription/openjd-model-for-python/blob/435971ac240c5fedf1c24310e9a3f50d487abaf6/.github/workflows/publish.yml#L35-L39

### What is the impact of this change?

Hopefully, the release will succeed.

### How was this change tested?

Wasn't. We'll test it in production :-)

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*