### PR TITLE
chore(release): add id-token: write perms to release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -38,6 +38,7 @@ jobs:
     needs: VerifyCommit
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
     env:
       CODEARTIFACT_REGION: "us-west-2"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release is broken due to missing `id-token: write` permission on job getting AWS credentials

### What was the solution? (How)
Add the permissions

### What is the impact of this change?
Release workflow hopefully works

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*