### PR TITLE
chore(release): export CODEARTIFACT_AUTH_TOKEN in release build

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -99,7 +99,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch build
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release build failed because the `CODEARTIFACT_AUTH_TOKEN` variable was not exported: https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/7834905515

### What was the solution? (How)
Export the variable

### What is the impact of this change?
Release workflow probably fixed

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*