### PR TITLE
chore(release): use CI token for merge back and use release environment

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -27,6 +27,7 @@ jobs:
   Bump:
     needs: TestMainline
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -37,6 +37,7 @@ jobs:
   Release:
     needs: VerifyCommit
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: write
@@ -113,6 +114,7 @@ jobs:
   MergeBack:
     needs: Release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
@@ -121,6 +123,7 @@ jobs:
         with:
           ref: mainline
           fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
 
       - name: MergeBackMainline
         run: |


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The `MergeBack` job for the 0.3.0 release failed due to the action runner not using our CI bot account to do the push, preventing it from pushing directly to `mainline`.
- The `CI_TOKEN` is currently available as a repo-level secret, meaning anyone can create a PR that uses the token and push changes as our CI bot account.

### What was the solution? (How)
- Use the CI bot account's token for the `MergeBack` job
- Move the `CI_TOKEN` into the `release` environment. The release environment has been updated to require an approval from "OpenJobDescription/developers" before running to prevent the above issue.

### What is the impact of this change?
- The `MergeBack` job in future releases will succeed
- Usage of the `CI_TOKEN` is gated behind "OpenJobDescription/developers" approval, reducing risk of malicious use of the token

### How was this change tested?
N/A

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*