### PR TITLE
fix: no longer shortcircuit validation if there are parameter reference errors

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -2217,8 +2217,11 @@ class JobTemplate(OpenJDModel_v2023_09):
             return validate_unique_elements(v, item_value=lambda v: v.name, property="name")
         return v
 
-    @root_validator(pre=True)
-    def _prevalidate_template_variable_references(cls, values: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _root_template_prevalidator(cls, values: dict[str, Any]) -> dict[str, Any]:
+        # The name of this validator is very important. It is specifically looked for
+        # in the _parse_model function to run this validation as a pre-root-validator
+        # without the usual short-circuit of pre-root-validators that pydantic does.
         errors = prevalidate_model_template_variable_references(
             cast(Type[OpenJDModel], cls), values
         )
@@ -2340,8 +2343,11 @@ class EnvironmentTemplate(OpenJDModel_v2023_09):
             return validate_unique_elements(v, item_value=lambda v: v.name, property="name")
         return v
 
-    @root_validator(pre=True)
-    def _prevalidate_template_variable_references(cls, values: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _root_template_prevalidator(cls, values: dict[str, Any]) -> dict[str, Any]:
+        # The name of this validator is very important. It is specifically looked for
+        # in the _parse_model function to run this validation as a pre-root-validator
+        # without the usual short-circuit of pre-root-validators that pydantic does.
         errors = prevalidate_model_template_variable_references(
             cast(Type[OpenJDModel], cls), values
         )

--- a/test/openjd/model/v2023_09/test_environment_template.py
+++ b/test/openjd/model/v2023_09/test_environment_template.py
@@ -222,7 +222,7 @@ class TestEnvironmentTemplate:
                         },
                     },
                 },
-                2,  # Validation of Job Foo & Task Foo
+                3,  # "Blah" is not a valid integer + Validation of Job Foo & Task Foo
                 id="all parameter symbols are defined when validation errors",
             ),
         ),

--- a/test/openjd/model/v2023_09/test_template_variables.py
+++ b/test/openjd/model/v2023_09/test_template_variables.py
@@ -19,7 +19,10 @@ STEP_SCRIPT = {"actions": {"onRun": {"command": "foo"}}}
 STEP_TEMPLATE = {"name": "StepName", "script": STEP_SCRIPT}
 STEP_SCRIPT_FOO = {
     "actions": {
-        "onRun": {"command": "foo {{Param.Foo}} {{RawParam.Foo}} {{Session.WorkingDirectory}}"}
+        "onRun": {
+            "command": "foo {{Param.Foo}} {{RawParam.Foo}} {{Session.WorkingDirectory}}",
+            "args": ["foo {{Param.Foo}} {{RawParam.Foo}} {{Session.WorkingDirectory}}"],
+        }
     }
 }
 STEP_TEMPLATE_FOO = {"name": "StepName", "script": STEP_SCRIPT_FOO}
@@ -520,8 +523,18 @@ class TestJobTemplate:
                     "name": "Foo",
                     "steps": [STEP_TEMPLATE_FOO],
                 },
-                2,
+                4,
                 id="step missing parameter",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Foo",
+                    "parmDef": [FOO_PARAMETER_INT],
+                    "steps": [STEP_TEMPLATE_FOO],
+                },
+                5,  # extra field + 2 param refs in each of command+args
+                id="key error and path parameter 'Foo' missing",
             ),
             pytest.param(
                 {
@@ -540,7 +553,7 @@ class TestJobTemplate:
                     "steps": [STEP_TEMPLATE_FOO],
                     "jobEnvironments": [ENVIRONMENT_FOO],
                 },
-                4,
+                6,
                 id="step and environment missing parameter",
             ),
             pytest.param(


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The improvement to validation errors implemented in https://github.com/OpenJobDescription/openjd-model-for-python/pull/47 introduced an error. If there are errors flagged for parameter references (e.g. definition of an unknown variable) then we are aborting the rest of the model validation. This can make diagnosing errors in a template harder than it should be. The root of the bug is that pydantic itself short-circuits model parsing if any pre-root-validator raises an error.

For example, validation of the following template will not show that the field 'parmeterDefinitions' is unknown (it should be 'parameterDefinitions' -- notice the missing 'a' in 'para'):

```
specificationVersion: jobtemplate-2023-09
name: DemoJob
parmeterDefinitions:
- name: Foo
  type: INT
steps:
- name: DemoStep
  script:
    actions:
      onRun:
        command: "{{Param.Foo}}"
```

So, one is left scratching there head wondering why 'Param.Foo' doesn't exist.

### What was the solution? (How)

I had to move the variable reference validation out of pydantic's validation flows. It doesn't work as a regular root validator (see the other PR for why), and we can't have it short-circuiting validation as a pre-root-validator. So, instead I've updated the _parse_model() function to run the variable reference validation if the model has a _root_template_prevalidator method defined.

This does come with a trade-off. We no longer run the template variable validation at all if the user is directly constructing a data model using the model classes. Adding a __init__() to JobTemplate and EnvironmentTemplate to force the validator to run ended up in doubling-up all variable reference validation errors. So, this'll have to be a tradeoff that we accept until a better solution comes around.

### What is the impact of this change?

Those using the CLI's `openjd check` and the `decode_job/environment_template()` methods to validate templates will no longer be left scratching there head when they make a typo in a parameter definition field and are seeing variable reference errors that don't make sense.

### How was this change tested?

The unit tests have been updated.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*