### PR TITLE
fix: update homepage url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/OpenJobDescription/openjd-specifications/wiki"
+Homepage = "https://github.com/OpenJobDescription/openjd-model-for-python"
 Source = "https://github.com/OpenJobDescription/openjd-model-for-python"
 
 [tool.hatch.build]


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

I'd set the homepage url to the specification repository rather than this project's repository because I wanted that to be considered the homepage. However, it looks like PyPI is populating the GitHub statistics of the project based off of the homepage rather than source page. 

### What was the solution? (How)

The PyPI page's stats should reflect this repo rather than the other, so let's change the homepage.

### What is the impact of this change?

GitHub stats on PyPI are accurate.

### How was this change tested?

N/A

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*