### PR TITLE
fix: correct the bad '\Z' escape sequence in a regex

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -118,7 +118,7 @@ class ValueReferenceConstants(Enum):
 #    C1 = 0x80-0x9F
 #         https://www.unicode.org/charts/PDF/U0080.pdf
 _Cc_characters = r"\u0000-\u001F\u007F-\u009F"
-_standard_string_regex = f"(?-m:^[^{_Cc_characters}]+\Z)"
+_standard_string_regex = rf"(?-m:^[^{_Cc_characters}]+\Z)"
 
 # Latin alphanumeric, starting with a letter
 _identifier_regex = r"(?-m:^[A-Za-z_][A-Za-z0-9_]*\Z)"
@@ -131,7 +131,9 @@ _identifier_regex = r"(?-m:^[A-Za-z_][A-Za-z0-9_]*\Z)"
 #    c. Wildcard characters "*", "?", "[", "]".
 #    d. Characters commonly disallowed in paths "#", "%", "&", "{", "}", "<", ">",
 #       "$", "!", "'", "\"", ":", "@", "`", "|", "=".
-_file_dialog_filter_pattern_regex = f"(?-m:^(?:\\*|\\*\\.\\*|\\*\\.[^{_Cc_characters}\\/\\*\\?\\[\\]#%&\\{{\\}}<>\\$\\!\\'\\\":@`\\|=]+)\Z)"
+_file_dialog_filter_pattern_regex = (
+    rf"(?-m:^(?:\*|\*\.\*|\*\.[^{_Cc_characters}\\/\*\?\[\]#%&\{{\}}<>\$\!'\\\":@`|=]+)\Z)"
+)
 
 
 class JobTemplateName(FormatString):


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

We're seeing errors in a mingw64 environment:
```
SyntaxWarning: invalid escape sequence '\Z'  _standard_string_regex = ...
SyntaxWarning: invalid escape sequence '\Z'  _file_dialog_filter_pattern_regex = ...
```

### What was the solution? (How)

These should be raw strings. '\Z' is a special regex marker signifying the end of string.

### What is the impact of this change?

Fewer bugs.

### How was this change tested?

Interestingly, these regexes are thoroughly tested in `test/model/v2023_09/test_strings.py` but we didn't see a problem there in the CI.

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*