### PR TITLE
feat: add validation that associative op's args are equal length

### DIFF
--- a/src/openjd/model/_internal/__init__.py
+++ b/src/openjd/model/_internal/__init__.py
@@ -8,11 +8,13 @@ from ._combination_expr import Node as CombinationExpressionNode
 from ._combination_expr import Parser as CombinationExpressionParser
 from ._combination_expr import ProductNode as CombinationExpressionProductNode
 from ._create_job import instantiate_model
+from ._param_space_dim_validation import validate_step_parameter_space_dimensions
 from ._variable_reference_validation import prevalidate_model_template_variable_references
 
 __all__ = (
     "instantiate_model",
     "prevalidate_model_template_variable_references",
+    "validate_step_parameter_space_dimensions",
     "validate_unique_elements",
     "CombinationExpressionAssociationNode",
     "CombinationExpressionIdentifierNode",

--- a/src/openjd/model/_internal/_param_space_dim_validation.py
+++ b/src/openjd/model/_internal/_param_space_dim_validation.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from functools import reduce
+from operator import mul
+from ._combination_expr import AssociationNode, IdentifierNode, Node, Parser, ProductNode
+from .._errors import ExpressionError
+
+
+def validate_step_parameter_space_dimensions(
+    parameter_range_lengths: dict[str, int], combination: str
+) -> None:
+    """This validates that a CombinationExpr satisfies constraints placed
+    on the ranges of the elements of the expression.
+    Specifically that the arguments to an Associative operator all have
+    the exact same number of elements.
+
+    Args:
+      - parameter_range_lengths: dict[str,int] -- A map from identifier name
+          to the number of elements in that parameter's range.
+      - combination: str -- The combination expression.
+
+    Raises:
+       ExpressionError if the combination expression violates constraints.
+    """
+    parse_tree = Parser().parse(combination)
+    _validate_expr_tree(parse_tree, parameter_range_lengths)
+
+
+def _validate_expr_tree(root: Node, parameter_range_lengths: dict[str, int]) -> int:
+    # Returns the length of the subtree while recursively validating it.
+    if isinstance(root, IdentifierNode):
+        name = root.parameter
+        return parameter_range_lengths[name]
+    elif isinstance(root, AssociationNode):
+        # Association requires that all arguments are the exact same length.
+        # Ensure that is the case
+        arg_lengths = tuple(
+            _validate_expr_tree(child, parameter_range_lengths) for child in root.children
+        )
+        if len(set(arg_lengths)) > 1:
+            raise ExpressionError(
+                (
+                    "Associative expressions must have arguments with identical ranges. "
+                    "Expression %s has argument lengths %s." % (str(root), arg_lengths)
+                )
+            )
+        return arg_lengths[0]
+    else:
+        # For type hinting
+        assert isinstance(root, ProductNode)
+        return reduce(
+            mul, (_validate_expr_tree(child, parameter_range_lengths) for child in root.children), 1
+        )

--- a/test/openjd/model/_internal/test_param_space_dim_validation.py
+++ b/test/openjd/model/_internal/test_param_space_dim_validation.py
@@ -1,0 +1,92 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+import re
+
+from openjd.model._internal import validate_step_parameter_space_dimensions
+from openjd.model import ExpressionError
+
+
+@pytest.mark.parametrize(
+    "param_ranges, combination",
+    [
+        pytest.param({"A": 5}, "A", id="Identifier"),
+        pytest.param({"A": 5, "B": 10}, "A * B", id="Product"),
+        pytest.param({"A": 5, "B": 5}, "(A,B)", id="Association"),
+        pytest.param({"A": 5, "B": 5, "C": 10}, "(A,B)*C", id="Association-Product"),
+        pytest.param({"A": 5, "B": 5, "C": 10}, "C*(A,B)", id="Product-Association"),
+        pytest.param({"A": 5, "B": 5, "C": 1}, "(A*C,B)", id="Nested product 2"),
+        pytest.param({"A": 5, "B": 5, "C": 1}, "(A,B*C)", id="Nested product 2"),
+        pytest.param({"A": 5, "B": 5, "C": 5}, "((A,C),B)", id="Nested association 1"),
+        pytest.param({"A": 5, "B": 5, "C": 5}, "(A,(B,C))", id="Nested association 2"),
+    ],
+)
+def test_allowable(param_ranges: dict[str, int], combination: str) -> None:
+    # Test that perfectly valid parameter spaces do not raise exceptions
+
+    # THEN
+    validate_step_parameter_space_dimensions(param_ranges, combination)
+
+
+@pytest.mark.parametrize(
+    "param_ranges, combination, expected_exception",
+    [
+        pytest.param(
+            {"A": 5, "B": 10},
+            "(A,B)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B) has argument lengths (5, 10).",
+            id="2-arg",
+        ),
+        pytest.param(
+            {"A": 5, "B": 10, "C": 10},
+            "(A,B,C)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B, C) has argument lengths (5, 10, 10).",
+            id="3-arg; A",
+        ),
+        pytest.param(
+            {"A": 10, "B": 5, "C": 10},
+            "(A,B,C)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B, C) has argument lengths (10, 5, 10).",
+            id="3-arg; B",
+        ),
+        pytest.param(
+            {"A": 10, "B": 10, "C": 5},
+            "(A,B,C)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B, C) has argument lengths (10, 10, 5).",
+            id="3-arg; C",
+        ),
+        pytest.param(
+            {"A": 5, "B": 5, "C": 5},
+            "(A,B*C)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B * C) has argument lengths (5, 25).",
+            id="Nested product",
+        ),
+        pytest.param(
+            {"A": 5, "B": 10, "C": 10},
+            "(A,(B,C))",
+            "Associative expressions must have arguments with identical ranges. Expression (A, (B, C)) has argument lengths (5, 10).",
+            id="Nested Association",
+        ),
+        pytest.param(
+            {"A": 5, "B": 10, "C": 10},
+            "C * (A,B)",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B) has argument lengths (5, 10).",
+            id="Recurse to association 1",
+        ),
+        pytest.param(
+            {"A": 5, "B": 10, "C": 10},
+            "(A,B) * C",
+            "Associative expressions must have arguments with identical ranges. Expression (A, B) has argument lengths (5, 10).",
+            id="Recurse to association 2",
+        ),
+    ],
+)
+def test_mismatched_association(
+    param_ranges: dict[str, int], combination: str, expected_exception: str
+) -> None:
+    # Test that expressions that contain associations with mismatched argument lengths
+    # all raise the expected exception.
+
+    # THEN
+    with pytest.raises(ExpressionError, match=re.escape(expected_exception)):
+        validate_step_parameter_space_dimensions(param_ranges, combination)


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The Open Job Description specification says "Every comma-separated expression within an associative operator must have the exact same number of values defined in their range." The current model validators to not ensure that this is the case.

Reference: https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#343-combinationexpr

### What was the solution? (How)

I've implemented `validate_step_parameter_space_dimensions()` to validate this constraint and added a validator to the StepParameterSpace to use it. My first inclination was to implement this validation as part of constructing the StepParameterSpaceIterator since it already has a recursive expression parse, but that is a chicken & egg problem; we need a StepParameterSpace to construct a StepParameterSpaceIterator, but we don't have one yet when doing validation for the construction of a StepParameterSpace.

### What is the impact of this change?

The model validator enforces a previously neglected constraint.

### How was this change tested?

I have added unit tests that fully cover the new functionality.

### Was this change documented?

Yes, in the official specification

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*