### PR TITLE
ci: install python-semantic-release via requirements file

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -28,10 +28,8 @@ build = "hatch build"
 
 [envs.release]
 detached = true
-dependencies = [
-  "python-semantic-release == 8.7.*"
-]
 
 [envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,1 @@
-# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
-# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 9.4.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
python-semantic-release is not being properly tracked by dependabot.

### What was the solution? (How)
Add a hatch script to install python-semantic-release from a requirements file

### What is the impact of this change?
Install python-semantic-release via an requirements file that is tracked by dependabot.

### How was this change tested?
`hatch run release:deps`

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*