### PR TITLE
fix: fix lint, Break up long regex over multiple lines

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -133,7 +133,10 @@ _identifier_regex = r"(?-m:^[A-Za-z_][A-Za-z0-9_]*\Z)"
 #    d. Characters commonly disallowed in paths "#", "%", "&", "{", "}", "<", ">",
 #       "$", "!", "'", "\"", ":", "@", "`", "|", "=".
 _file_dialog_filter_pattern_regex = (
-    rf"(?-m:^(?:\*|\*\.\*|\*\.[^{_Cc_characters}\\/\*\?\[\]#%&\{{\}}<>\$\!'\\\":@`|=]+)\Z)"
+    rf"(?-m:^(?:\*|\*\.\*|\*\."
+    rf"[^{_Cc_characters}\\/\*"
+    rf"\?\[\]#%&\{{\}}<>\$\!'"
+    rf"\\\":@`|=]+)\Z)"
 )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A long regex was failing linting
### What was the solution? (How)
break the regex over multiple lines
### What is the impact of this change?
linting should be fixed unblocking all other PR
### How was this change tested?
* `hatch -v run lint`
* `hatch run test`
### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*