### PR TITLE
revert: "chore(release): 0.4.3"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.4.3 (2024-06-03)
-
-
-
-### Bug Fixes
-* fix lint, Break up long regex over multiple lines (#116) ([`3801c80`](https://github.com/OpenJobDescription/openjd-model-for-python/commit/3801c8034956112954c6f76a6cedf49e6d5a7f31))
-
 ## 0.4.2 (2024-03-27)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
CI change needed to be made for publishing. 0.4.3 changelog need to be reverted so release can be performed again.

### What was the solution? (How)
revert 0.4.3 change log

### What is the impact of this change?
Add publishing to CI

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*