### PR TITLE
feat: add merge_job_parameter_definitions to public api

### DIFF
--- a/src/openjd/model/__init__.py
+++ b/src/openjd/model/__init__.py
@@ -10,6 +10,7 @@ from ._errors import (
     TokenError,
     UnsupportedSchema,
 )
+from ._merge_job_parameter import merge_job_parameter_definitions
 from ._range_expr import IntRangeExpr
 from ._parse import (
     DocumentType,
@@ -52,6 +53,7 @@ __all__ = (
     "decode_environment_template",
     "decode_job_template",
     "document_string_to_object",
+    "merge_job_parameter_definitions",
     "model_to_object",
     "parse_model",
     "preprocess_job_parameters",


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The merge_job_parameter_definitions function can be used to test Job Parameter compatibility between a Job Template and a set of Environment Templates. It is currently a private function, but is useful to consumers of this library.

### What was the solution? (How)

 So, we move it to the public API.

### What is the impact of this change?

More functionality available in the public API.

### How was this change tested?

N/A

### Was this change documented?

Yes, the function has a docstring.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*