### PR TITLE
fix: format string errors no longer embed the entire format string

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:src test}",
+  "ruff check {args:src test}",
   "black --check --diff {args:src test}",
 ]
 fmt = [

--- a/src/openjd/model/_format_strings/_format_string.py
+++ b/src/openjd/model/_format_strings/_format_string.py
@@ -26,8 +26,7 @@ class FormatStringError(Exception):
         expression = f"Expression: {expr}. " if expr else ""
         reason = f"Reason: {details}." if details else ""
         msg = (
-            f"Failed to parse interpolation expression in {string} "
-            f"at [{start}, {end}]. "
+            f"Failed to parse interpolation expression at [{start}, {end}]. "
             f"{expression}"
             f"{reason}"
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Format strings can be very large (e.g. when they are the 'data' element of an embedded file). The FormatStringError that we report currently embeds the entire format string into the error message. That's unnecessary since our validation errors are already pointing the user directly at the template element that is producing the error.

### What was the solution? (How)

This removes the format string data from the error message.

### What is the impact of this change?

Easier to read/understand format string error messages.

### How was this change tested?

Just running the unit tests.

### Was this change documented?

N/A

### Is this a breaking change?

No, the contents of an error string is not a contract.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*