### PR TITLE
feat!: compatibility with pydantic v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "pyyaml == 6.0.*",
-  "pydantic ~= 1.10",
+  "pydantic >= 1.10.17",
 ]
 
 [project.urls]
@@ -99,7 +99,7 @@ mypy_path = "src"
 
 # See: https://docs.pydantic.dev/mypy_plugin/
 #  - Helps mypy understand pydantic typing.
-plugins = "pydantic.mypy"
+plugins = "pydantic.v1.mypy"
 
 [tool.ruff]
 line-length = 100

--- a/src/openjd/model/_convert_pydantic_error.py
+++ b/src/openjd/model/_convert_pydantic_error.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from typing import TypedDict, Union, Type
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from inspect import getmodule
 
 # Calling pydantic's ValidationError.errors() returns a list[ErrorDict], but

--- a/src/openjd/model/_create_job.py
+++ b/src/openjd/model/_create_job.py
@@ -4,7 +4,7 @@ from os.path import normpath
 from pathlib import Path
 from typing import Optional, cast
 
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from ._errors import CompatibilityError, DecodeValidationError
 from ._symbol_table import SymbolTable

--- a/src/openjd/model/_format_strings/_dyn_constrained_str.py
+++ b/src/openjd/model/_format_strings/_dyn_constrained_str.py
@@ -3,12 +3,12 @@
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional, Pattern, Union
 
-from pydantic.errors import AnyStrMaxLengthError, AnyStrMinLengthError, StrRegexError
-from pydantic.utils import update_not_none
-from pydantic.validators import strict_str_validator
+from pydantic.v1.errors import AnyStrMaxLengthError, AnyStrMinLengthError, StrRegexError
+from pydantic.v1.utils import update_not_none
+from pydantic.v1.validators import strict_str_validator
 
 if TYPE_CHECKING:
-    from pydantic.typing import CallableGenerator
+    from pydantic.v1.typing import CallableGenerator
 
 
 class DynamicConstrainedStr(str):

--- a/src/openjd/model/_format_strings/_format_string.py
+++ b/src/openjd/model/_format_strings/_format_string.py
@@ -10,7 +10,7 @@ from ._dyn_constrained_str import DynamicConstrainedStr
 from ._expression import InterpolationExpression
 
 if TYPE_CHECKING:
-    from pydantic.typing import CallableGenerator
+    from pydantic.v1.typing import CallableGenerator
 
 
 @dataclass

--- a/src/openjd/model/_internal/_create_job.py
+++ b/src/openjd/model/_internal/_create_job.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Union
 
-from pydantic import ValidationError
-from pydantic.error_wrappers import ErrorWrapper
+from pydantic.v1 import ValidationError
+from pydantic.v1.error_wrappers import ErrorWrapper
 
 from .._symbol_table import SymbolTable
 from .._format_strings import FormatString, FormatStringError

--- a/src/openjd/model/_parse.py
+++ b/src/openjd/model/_parse.py
@@ -7,9 +7,9 @@ from enum import Enum
 from typing import Any, ClassVar, Optional, Type, TypeVar, Union, cast
 
 import yaml
-from pydantic import BaseModel
-from pydantic import ValidationError as PydanticValidationError
-from pydantic.error_wrappers import ErrorWrapper
+from pydantic.v1 import BaseModel
+from pydantic.v1 import ValidationError as PydanticValidationError
+from pydantic.v1.error_wrappers import ErrorWrapper
 
 from ._errors import DecodeValidationError
 from ._types import EnvironmentTemplate, JobTemplate, OpenJDModel, TemplateSpecificationVersion

--- a/src/openjd/model/_types.py
+++ b/src/openjd/model/_types.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Type, Union
 
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 
 from ._symbol_table import SymbolTable
 

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -9,7 +9,7 @@ from graphlib import CycleError, TopologicalSorter
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Type, Union, cast
 from typing_extensions import Annotated
 
-from pydantic import (
+from pydantic.v1 import (
     Field,
     PositiveInt,
     PositiveFloat,
@@ -22,7 +22,7 @@ from pydantic import (
     root_validator,
     validator,
 )
-from pydantic.error_wrappers import ErrorWrapper
+from pydantic.v1.error_wrappers import ErrorWrapper
 
 from .._format_strings import FormatString
 from .._errors import ExpressionError, TokenError

--- a/test/openjd/model/_internal/test_create_job.py
+++ b/test/openjd/model/_internal/test_create_job.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Optional, Union, cast
 
 import pytest
-from pydantic import PositiveInt, ValidationError
+from pydantic.v1 import PositiveInt, ValidationError
 
 from openjd.model import SymbolTable
 from openjd.model._format_strings import FormatString

--- a/test/openjd/model/_internal/test_variable_reference_validation.py
+++ b/test/openjd/model/_internal/test_variable_reference_validation.py
@@ -3,7 +3,7 @@
 from typing import Any, Literal, Union
 from enum import Enum
 from typing_extensions import Annotated
-from pydantic import Field
+from pydantic.v1 import Field
 
 import pytest
 

--- a/test/openjd/model/format_strings/test_dyn_constrained_str.py
+++ b/test/openjd/model/format_strings/test_dyn_constrained_str.py
@@ -3,7 +3,7 @@
 import re
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 from openjd.model._format_strings._dyn_constrained_str import DynamicConstrainedStr
 

--- a/test/openjd/model/test_convert_pydantic_error.py
+++ b/test/openjd/model/test_convert_pydantic_error.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from pydantic import BaseModel, root_validator, Field
+from pydantic.v1 import BaseModel, root_validator, Field
 from typing import Literal, Union
 
 from openjd.model._convert_pydantic_error import (

--- a/test/openjd/model/v2023_09/test_action.py
+++ b/test/openjd/model/v2023_09/test_action.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import Action, EnvironmentActions, StepActions

--- a/test/openjd/model/v2023_09/test_definitions.py
+++ b/test/openjd/model/v2023_09/test_definitions.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from typing import Type
 import openjd.model.v2023_09 as mod
 from inspect import getmembers, getmodule, isclass

--- a/test/openjd/model/v2023_09/test_embedded.py
+++ b/test/openjd/model/v2023_09/test_embedded.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import EmbeddedFileText

--- a/test/openjd/model/v2023_09/test_environment_template.py
+++ b/test/openjd/model/v2023_09/test_environment_template.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import EnvironmentTemplate

--- a/test/openjd/model/v2023_09/test_environments.py
+++ b/test/openjd/model/v2023_09/test_environments.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import Environment

--- a/test/openjd/model/v2023_09/test_job_parameters.py
+++ b/test/openjd/model/v2023_09/test_job_parameters.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_job_template.py
+++ b/test/openjd/model/v2023_09/test_job_template.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import JobTemplate

--- a/test/openjd/model/v2023_09/test_parameter_space.py
+++ b/test/openjd/model/v2023_09/test_parameter_space.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_scripts.py
+++ b/test/openjd/model/v2023_09/test_scripts.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import EnvironmentScript, StepScript

--- a/test/openjd/model/v2023_09/test_step_host_requirements.py
+++ b/test/openjd/model/v2023_09/test_step_host_requirements.py
@@ -4,7 +4,7 @@ from typing import Any
 import string
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import (

--- a/test/openjd/model/v2023_09/test_step_template.py
+++ b/test/openjd/model/v2023_09/test_step_template.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import StepTemplate

--- a/test/openjd/model/v2023_09/test_strings.py
+++ b/test/openjd/model/v2023_09/test_strings.py
@@ -4,7 +4,7 @@ from typing import Any
 import string
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel, ValidationError
 
 from openjd.model.v2023_09 import (
     AmountCapabilityName,

--- a/test/openjd/model/v2023_09/test_template_variables.py
+++ b/test/openjd/model/v2023_09/test_template_variables.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from openjd.model._parse import _parse_model
 from openjd.model.v2023_09 import JobTemplate


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-model-for-python/issues/107

### What was the problem/requirement? (What/Why)

Pydantic v1 is EOL, but some users of this library still use it. Those users would like to update to pydantic v2, but this library needs to be compatible with it for that to happen.

### What was the solution? (How)

Pydantic v2 contains the pydantic v1 in the pydantic.v1 namespace, and pydantic v1.10.17+ also contains this same namespace. So, step one to migrating to Pydantic v2 is to use the pydantic.v1 namespace throughout. Then, in future, the models can be updated to true Pydantic v2 when all consumers are ready for it.

### What is the impact of this change?

Consumers of this library can now update to a newer Pydantic without this library blocking them.

### How was this change tested?

The unit tests pass. I've run the tests both with pydantic 1.10.18 and pydantic 2.9.2.

### Was this change documented?

- Are relevant docstrings in the code base updated?

### Is this a breaking change?

I'm marking this as a breaking change since the pydantic library update is not backwards compatible.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*