### PR TITLE
fix: improve parameter definition validation and error reporting

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -56,6 +56,11 @@ from .._types import (
     TemplateVariableDef,
 )
 
+# Error message constants
+_ALLOWED_VALUES_NONE_ERROR = "allowedValues cannot be None. The field must contain at least one value or be omitted entirely."
+_VALUE_LESS_THAN_MIN_ERROR = "Value less than minValue."
+_VALUE_LARGER_THAN_MAX_ERROR = "Value larger than maxValue."
+
 
 class ModelParsingContext(ModelParsingContextInterface):
     """Context required while parsing an OpenJDModel. An instance of this class
@@ -1211,6 +1216,8 @@ class JobStringParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
     def _validate_allowed_values_item(
         cls, value: AllowedParameterStringValueList, info: ValidationInfo
     ) -> AllowedParameterStringValueList:
+        if value is None:
+            raise ValueError(_ALLOWED_VALUES_NONE_ERROR)
         min_length = info.data.get("minLength")
         max_length = info.data.get("maxLength")
         errors = list[InitErrorDetails]()
@@ -1421,7 +1428,7 @@ class JobPathParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
             "default",
         },
         adds_fields=lambda this, symtab: {
-            "value": symtab[f"RawParam.{cast(JobStringParameterDefinition,this).name}"]
+            "value": symtab[f"RawParam.{cast(JobPathParameterDefinition,this).name}"]
         },
     )
 
@@ -1451,8 +1458,10 @@ class JobPathParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
     @field_validator("allowedValues")
     @classmethod
     def _validate_allowed_values_item(
-        cls, value: ParameterStringValue, info: ValidationInfo
-    ) -> ParameterStringValue:
+        cls, value: AllowedParameterStringValueList, info: ValidationInfo
+    ) -> AllowedParameterStringValueList:
+        if value is None:
+            raise ValueError(_ALLOWED_VALUES_NONE_ERROR)
         min_length = info.data.get("minLength")
         max_length = info.data.get("maxLength")
         errors = list[InitErrorDetails]()
@@ -1462,7 +1471,7 @@ class JobPathParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
                     errors.append(
                         InitErrorDetails(
                             type="value_error",
-                            loc=("allowedValues", i),
+                            loc=(i,),
                             ctx={"error": ValueError("Value is shorter than minLength.")},
                             input=item,
                         )
@@ -1472,7 +1481,7 @@ class JobPathParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
                     errors.append(
                         InitErrorDetails(
                             type="value_error",
-                            loc=("allowedValues", i),
+                            loc=(i,),
                             ctx={"error": ValueError("Value is longer than maxLength.")},
                             input=item,
                         )
@@ -1610,7 +1619,7 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
         allowedValues (Optional[AllowedIntParameterList]): Explicit list of values that the
             parameter is allowed to take on.
         minValue (Optional[int]): Minimum value that the parameter is allowed to be.
-        maxValue (Optional[int]): Minimum value that the parameter is allowed to be.
+        maxValue (Optional[int]): Maximum value that the parameter is allowed to be.
     """
 
     name: Identifier
@@ -1671,7 +1680,12 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
 
     @field_validator("allowedValues", mode="before")
     @classmethod
-    def _validate_allowed_values_item_type(cls, value: Any) -> Any:
+    def _validate_allowed_values_item_type(
+        cls, value: AllowedIntParameterList
+    ) -> AllowedIntParameterList:
+        if value is None:
+            raise ValueError(_ALLOWED_VALUES_NONE_ERROR)
+
         errors = list[InitErrorDetails]()
         for i, item in enumerate(value):
             if isinstance(item, bool) or not isinstance(item, (int, str)):
@@ -1712,7 +1726,11 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
 
     @field_validator("allowedValues")
     @classmethod
-    def _validate_allowed_values_item(cls, value: list[int], info: ValidationInfo) -> list[int]:
+    def _validate_allowed_values_item(
+        cls, value: AllowedIntParameterList, info: ValidationInfo
+    ) -> AllowedIntParameterList:
+        if value is None:
+            raise ValueError(_ALLOWED_VALUES_NONE_ERROR)
         min_value = info.data.get("minValue")
         max_value = info.data.get("maxValue")
         errors = list[InitErrorDetails]()
@@ -1723,7 +1741,7 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
                         InitErrorDetails(
                             type="value_error",
                             loc=(i,),
-                            ctx={"error": ValueError("Value less than minValue.")},
+                            ctx={"error": ValueError(_VALUE_LESS_THAN_MIN_ERROR)},
                             input=item,
                         )
                     )
@@ -1733,7 +1751,7 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
                         InitErrorDetails(
                             type="value_error",
                             loc=(i,),
-                            ctx={"error": ValueError("Value larger than minValue.")},
+                            ctx={"error": ValueError(_VALUE_LARGER_THAN_MAX_ERROR)},
                             input=item,
                         )
                     )
@@ -1747,11 +1765,11 @@ class JobIntParameterDefinition(OpenJDModel_v2023_09):
         min_value = info.data.get("minValue")
         if min_value is not None:
             if value < min_value:
-                raise ValueError("Value less than minValue.")
+                raise ValueError(_VALUE_LESS_THAN_MIN_ERROR)
         max_value = info.data.get("maxValue")
         if max_value is not None:
             if value > max_value:
-                raise ValueError("Value larger than maxValue.")
+                raise ValueError(_VALUE_LARGER_THAN_MAX_ERROR)
 
         allowed_values = info.data.get("allowedValues")
         if allowed_values is not None:
@@ -1856,7 +1874,7 @@ class JobFloatParameterDefinition(OpenJDModel_v2023_09):
         allowedValues (Optional[AllowedFloatParameterList]): Explicit list of values that the
             parameter is allowed to take on.
         minValue (Optional[Decimal]): Minimum value that the parameter is allowed to be.
-        maxValue (Optional[Decimal]): Minimum value that the parameter is allowed to be.
+        maxValue (Optional[Decimal]): Maximum value that the parameter is allowed to be.
     """
 
     name: Identifier
@@ -1909,8 +1927,10 @@ class JobFloatParameterDefinition(OpenJDModel_v2023_09):
     @field_validator("allowedValues")
     @classmethod
     def _validate_allowed_values_item(
-        cls, value: list[Decimal], info: ValidationInfo
-    ) -> list[Decimal]:
+        cls, value: AllowedFloatParameterList, info: ValidationInfo
+    ) -> AllowedFloatParameterList:
+        if value is None:
+            raise ValueError(_ALLOWED_VALUES_NONE_ERROR)
         min_value = info.data.get("minValue")
         max_value = info.data.get("maxValue")
         errors = list[InitErrorDetails]()
@@ -1921,7 +1941,7 @@ class JobFloatParameterDefinition(OpenJDModel_v2023_09):
                         InitErrorDetails(
                             type="value_error",
                             loc=(i,),
-                            ctx={"error": ValueError("Value less than minValue.")},
+                            ctx={"error": ValueError(_VALUE_LESS_THAN_MIN_ERROR)},
                             input=item,
                         )
                     )
@@ -1931,7 +1951,7 @@ class JobFloatParameterDefinition(OpenJDModel_v2023_09):
                         InitErrorDetails(
                             type="value_error",
                             loc=(i,),
-                            ctx={"error": ValueError("Value larger than maxValue.")},
+                            ctx={"error": ValueError(_VALUE_LARGER_THAN_MAX_ERROR)},
                             input=item,
                         )
                     )
@@ -1945,11 +1965,11 @@ class JobFloatParameterDefinition(OpenJDModel_v2023_09):
         min_value = info.data.get("minValue")
         if min_value is not None:
             if value < min_value:
-                raise ValueError("Value less than minValue.")
+                raise ValueError(_VALUE_LESS_THAN_MIN_ERROR)
         max_value = info.data.get("maxValue")
         if max_value is not None:
             if value > max_value:
-                raise ValueError("Value larger than maxValue.")
+                raise ValueError(_VALUE_LARGER_THAN_MAX_ERROR)
 
         allowed_values = info.data.get("allowedValues")
         if allowed_values is not None:

--- a/test/openjd/model/v2023_09/test_job_parameters.py
+++ b/test/openjd/model/v2023_09/test_job_parameters.py
@@ -152,6 +152,13 @@ class TestJobStringParameterDefinition:
                 },
                 id="all fields",
             ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "STRING",
+                },
+                id="allowedValues not provided",
+            ),
         ),
     )
     def test_parse_success(self, data: dict[str, Any]) -> None:
@@ -194,6 +201,14 @@ class TestJobStringParameterDefinition:
             ),
             pytest.param(
                 {"name": "Foo", "type": "STRING", "allowedValues": []}, id="allowedValues too small"
+            ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "STRING",
+                    "allowedValues": None,
+                },
+                id="allowedValues is explicitly None",
             ),
             pytest.param(
                 {"name": "Foo", "type": "STRING", "allowedValues": [12]},
@@ -315,6 +330,54 @@ class TestJobStringParameterDefinition:
 
         # THEN
         assert len(excinfo.value.errors()) > 0
+
+    def test_allowedvalues_minlength_error_location(self) -> None:
+        # Test that error location reporting includes the field name and index for minLength validation
+        data = {
+            "name": "Foo",
+            "type": "STRING",
+            "minLength": 10,  # Make this larger to ensure validation fails
+            "allowedValues": ["short", "short", "long_enough_value"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobStringParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        assert any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 1) for error in errors)
+        # Verify that the third value doesn't trigger an error (it's long enough)
+        assert not any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value is shorter than minLength" in str(excinfo.value)
+
+    def test_allowedvalues_maxlength_error_location(self) -> None:
+        # Test that error location reporting includes the field name and index for maxLength validation
+        data = {
+            "name": "Foo",
+            "type": "STRING",
+            "maxLength": 2,  # Make this smaller to ensure validation fails
+            "allowedValues": ["ok", "ok", "too_long_value"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobStringParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        # Only the third value should fail (it's too long)
+        assert not any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert not any(error["loc"] == ("allowedValues", 1) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value is longer than maxLength" in str(excinfo.value)
 
     @pytest.mark.parametrize(
         "value,parameter",
@@ -591,6 +654,13 @@ class TestJobPathParameterDefinition:
                 },
                 id="all fields",
             ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "PATH",
+                },
+                id="allowedValues not provided",
+            ),
         ),
     )
     def test_parse_success(self, data: dict[str, Any]) -> None:
@@ -625,6 +695,14 @@ class TestJobPathParameterDefinition:
             pytest.param({"name": "Foo", "type": "PATH", "maxLength": "1"}, id="max length string"),
             pytest.param(
                 {"name": "Foo", "type": "PATH", "allowedValues": []}, id="allowedValues too small"
+            ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "PATH",
+                    "allowedValues": None,
+                },
+                id="allowedValues is explicitly None",
             ),
             pytest.param(
                 {"name": "Foo", "type": "PATH", "allowedValues": [12]},
@@ -908,6 +986,54 @@ class TestJobPathParameterDefinition:
         # THEN
         assert len(excinfo.value.errors()) > 0
 
+    def test_allowedvalues_minlength_error_location(self) -> None:
+        # Test that error location reporting includes the field name and index for minLength validation
+        data = {
+            "name": "Foo",
+            "type": "PATH",
+            "minLength": 10,  # Make this larger to ensure validation fails
+            "allowedValues": ["short", "short", "long_enough_value"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobPathParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        assert any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 1) for error in errors)
+        # Verify that the third value doesn't trigger an error (it's long enough)
+        assert not any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value is shorter than minLength" in str(excinfo.value)
+
+    def test_allowedvalues_maxlength_error_location(self) -> None:
+        # Test that error location reporting includes the field name and index for maxLength validation
+        data = {
+            "name": "Foo",
+            "type": "PATH",
+            "maxLength": 2,  # Make this smaller to ensure validation fails
+            "allowedValues": ["ok", "ok", "too_long_value"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobPathParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        # Only the third value should fail (it's too long)
+        assert not any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert not any(error["loc"] == ("allowedValues", 1) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value is longer than maxLength" in str(excinfo.value)
+
     @pytest.mark.parametrize(
         "value,parameter",
         [
@@ -1105,6 +1231,13 @@ class TestJobIntParameterDefinition:
                 },
                 id="all fields",
             ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "INT",
+                },
+                id="allowedValues not provided",
+            ),
         ),
     )
     def test_parse_success(self, data: dict[str, Any]) -> None:
@@ -1135,6 +1268,14 @@ class TestJobIntParameterDefinition:
             #
             pytest.param(
                 {"name": "Foo", "type": "INT", "allowedValues": []}, id="allowedValues too small"
+            ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "INT",
+                    "allowedValues": None,
+                },
+                id="allowedValues is explicitly None",
             ),
             pytest.param(
                 {"name": "Foo", "type": "INT", "allowedValues": ["aa"]},
@@ -1274,6 +1415,54 @@ class TestJobIntParameterDefinition:
 
         # THEN
         assert len(excinfo.value.errors()) > 0
+
+    def test_allowedvalues_minvalue_error_location_int(self) -> None:
+        # Test that error location reporting includes the field name and index for minValue validation
+        data = {
+            "name": "Foo",
+            "type": "INT",
+            "minValue": 10,  # Make this larger to ensure validation fails
+            "allowedValues": [5, 6, 15],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobIntParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        assert any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 1) for error in errors)
+        # Verify that the third value doesn't trigger an error (it's large enough)
+        assert not any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value less than minValue" in str(excinfo.value)
+
+    def test_allowedvalues_maxvalue_error_location_int(self) -> None:
+        # Test that error location reporting includes the field name and index for maxValue validation
+        data = {
+            "name": "Foo",
+            "type": "INT",
+            "maxValue": 10,
+            "allowedValues": [5, 10, 15],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobIntParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        # Only the third value should fail (it's too large)
+        assert not any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert not any(error["loc"] == ("allowedValues", 1) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value larger than maxValue" in str(excinfo.value)
 
     @pytest.mark.parametrize(
         "value,parameter",
@@ -1500,6 +1689,13 @@ class TestJobFloatParameterDefinition:
                 },
                 id="all fields",
             ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "FLOAT",
+                },
+                id="allowedValues not provided",
+            ),
         ),
     )
     def test_parse_success(self, data: dict[str, Any]) -> None:
@@ -1529,6 +1725,14 @@ class TestJobFloatParameterDefinition:
             ),
             pytest.param(
                 {"name": "Foo", "type": "FLOAT", "allowedValues": []}, id="allowedValues too small"
+            ),
+            pytest.param(
+                {
+                    "name": "Foo",
+                    "type": "FLOAT",
+                    "allowedValues": None,
+                },
+                id="allowedValues is explicitly None",
             ),
             pytest.param(
                 {"name": "Foo", "type": "FLOAT", "allowedValues": ["aa"]},
@@ -1638,6 +1842,54 @@ class TestJobFloatParameterDefinition:
 
         # THEN
         assert len(excinfo.value.errors()) > 0
+
+    def test_allowedvalues_minvalue_error_location_float(self) -> None:
+        # Test that error location reporting includes the field name and index for minValue validation
+        data = {
+            "name": "Foo",
+            "type": "FLOAT",
+            "minValue": "10.0",  # Make this larger to ensure validation fails
+            "allowedValues": ["5.0", "6.0", "15.0"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobFloatParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        assert any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 1) for error in errors)
+        # Verify that the third value doesn't trigger an error (it's large enough)
+        assert not any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value less than minValue" in str(excinfo.value)
+
+    def test_allowedvalues_maxvalue_error_location_float(self) -> None:
+        # Test that error location reporting includes the field name and index for maxValue validation
+        data = {
+            "name": "Foo",
+            "type": "FLOAT",
+            "maxValue": "10.0",
+            "allowedValues": ["5.0", "10.0", "15.0"],
+        }
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=JobFloatParameterDefinition, obj=data)
+
+        # THEN
+        errors = excinfo.value.errors()
+        assert len(errors) > 0
+        # Check that the error location includes both "allowedValues" and the index
+        # Only the third value should fail (it's too large)
+        assert not any(error["loc"] == ("allowedValues", 0) for error in errors)
+        assert not any(error["loc"] == ("allowedValues", 1) for error in errors)
+        assert any(error["loc"] == ("allowedValues", 2) for error in errors)
+        # Check the error message
+        assert "Value larger than maxValue" in str(excinfo.value)
 
     @pytest.mark.parametrize(
         "value,parameter",


### PR DESCRIPTION
# Fix parameter definition validation and error reporting

This PR improves parameter definition validation across all parameter types to properly handle `allowedValues` and provide clearer error messages.

Fixes: https://github.com/OpenJobDescription/openjd-model-for-python/issues/179

### What was the problem/requirement? (What/Why)

There were several issues with parameter definition validation:
1. The validators were rejecting explicit `None` values for `allowedValues`, without a clear error message
2. Error location reporting was inconsistent in validation error messages
3. Documentation comments for `maxValue` parameters incorrectly described them as "Minimum value"
4. Type casting in `JobPathParameterDefinition` was using the wrong class name

### What was the solution? (How)

1. Added explicit validation for `None` values in `allowedValues` across all parameter types (String, Path, Int, Float) with clear error messages
2. Fixed error location reporting in validation error messages to use consistent `("allowedValues", i)` format
3. Corrected documentation comments for `maxValue` parameters to say "Maximum value"
4. Fixed type casting in `JobPathParameterDefinition` to use the correct class name
5. Added test cases for both implicit and explicit `None` handling

### What is the impact of this change?

This change ensures that:
1. Explicitly set `None` values for `allowedValues` are properly rejected with clear error messages
2. Implicitly omitted `allowedValues` continue to work correctly
3. Error messages are more consistent and accurate across all parameter types
4. Documentation comments correctly describe parameter constraints

### How was this change tested?

Added test cases for both implicit and explicit `None` handling across all parameter types. All existing and new tests pass successfully.

- Have you run the unit tests?
Yes, all unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
Yes, fixed incorrect documentation comments for `maxValue` parameters.

### Is this a breaking change?

No, this is not a breaking change. It improves validation to reject invalid inputs that should have been rejected before, while maintaining compatibility with valid inputs. The error message itself has changed, which could be considered a breaking change but the benefit should be worth it. Compare:
```
'NoneType' object is not iterable
```
to
```
allowedValues cannot be None. The field must contain at least one value or be omitted entirely.
```

### Does this change impact security?

- Does the change need to be threat modeled?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*