### PR TITLE
fix: EnvironmentActions validation edge case

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -351,6 +351,9 @@ class EnvironmentActions(OpenJDModel_v2023_09):
     @classmethod
     def _requires_oneof(cls, values: dict[str, Any]) -> dict[str, Any]:
         """A validator that runs on the model data before parsing."""
+        if not isinstance(values, dict):
+            raise ValueError("Expected a dictionary of values")
+
         on_enter = values.get("onEnter")
         on_exit = values.get("onExit")
         if on_enter is None and on_exit is None:

--- a/test/openjd/model/v2023_09/test_template_variables.py
+++ b/test/openjd/model/v2023_09/test_template_variables.py
@@ -1128,6 +1128,17 @@ PARAMETRIZE_CASES = (
         2,  # Validation of Job Foo & Task Foo
         id="all parameter symbols are defined when validation errors",
     ),
+    pytest.param(
+        {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "Foo",
+            "parameterDefinitions": [FOO_PARAMETER_STRING],
+            "steps": [STEP_TEMPLATE_FOO],
+            "jobEnvironments": [{"name": "VariableEnv", "script": {"actions": []}}],
+        },
+        1,
+        id="jobEnvironments.script.actions needs to be a dict",
+    ),
 )
 
 


### PR DESCRIPTION
The EnvironmentActions oneOf validator assumed that actions was a dictionary.

If the template being validated had an environment action of any other type then an AttributeError would throw

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
If the template being validated had an environment action of any type other than a dict then an AttributeError would throw

### What was the solution? (How)

The requires_oneof first ensures that the action is a Dict before continuing


### What is the impact of this change?
openjd check will no longer crash when presented with a template with this sort of error

### How was this change tested?
A new unit test was added

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
yes

### Was this change documented?
no

- Are relevant docstrings in the code base updated?
no, not sure there are any.

### Is this a breaking change?
no

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the
[Public Interfaces](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#the-packages-public-interface) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
no

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*