### PR TITLE
chore: pydanticv2 deprecation warning - access model_fields through class

### DIFF
--- a/src/openjd/model/_internal/_create_job.py
+++ b/src/openjd/model/_internal/_create_job.py
@@ -80,7 +80,7 @@ def instantiate_model(  # noqa: C901
         elif create_as_metadata.callable is not None:
             target_model = create_as_metadata.callable(model)
 
-    for field_name in model.model_fields.keys():
+    for field_name in model.__class__.model_fields.keys():
         if field_name in model._job_creation_metadata.exclude_fields:
             # The field is marked for being excluded
             continue


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Warnings when running tests:

```
$ hatch run test
...
==== warnings summary ====
test/openjd/model/_internal/test_create_job.py: 35 warnings
test/openjd/model/test_create_job.py: 20 warnings
test/openjd/model/test_step_dependency_graph.py: 602 warnings
test/openjd/model/v2023_09/test_create.py: 49 warnings
test/openjd/model/test_step_param_space_iter.py: 10 warnings
 openjd-model-for-python/src/openjd/model/_internal/_create_job.py:83: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    for field_name in model.model_fields.keys():
...
==== 2154 passed, 716 warnings in 4.18s ====
```

### What was the solution? (How)

Use `model.__class__` to access the values

### What is the impact of this change?

No more warnings in this package and downstream consumers (ie. openjd-cli)!

### How was this change tested?

```
$ hatch build && hatch run lint && hatch run test
...
==== 2154 passed in 4.29s ====
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*