### PR TITLE
chore: add allow_zero_version to pyproject.toml in response to semant…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ fail_under = 94
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
What was the problem/requirement? (What/Why)

Semantic release broke a default setting so it would force our project to go version 1.0.0.
What was the solution? (How)

Add a flag in the pyproject.toml to re-enable zero versions.
What is the impact of this change?

Gets back to our version structure
How was this change tested?

N/A
Was this change documented?

No.
Is this a breaking change?
No.