### PR TITLE
chore: Allow zero version for Semantic Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ fail_under = 94
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Bump actions automatically go to 1.0.0 due to a change in Semantic Release.

### What was the solution? (How)
Add a flag to `pyproject.toml` to retain 0 version.

### What is the impact of this change?
No unwanted version bumps :)

### How was this change tested?
n/a

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-model-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
  Yes just for thoroughness

### Was this change documented?
n/a

### Is this a breaking change?

nop

### Does this change impact security?

nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*