### PR TITLE
chore: add responded and stale issue/pr workflows

### DIFF
--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -3,11 +3,6 @@ on:
     issue_comment:
         types: [created, edited]
 
-permissions:
-  issues: write
-  pull-requests: write
-  contents: read
-
 jobs:
     check-for-response:
         uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,0 +1,9 @@
+name: Contributor Responded
+on:
+    issue_comment:
+        types: [created, edited]
+
+jobs:
+    label-new-prs:
+        uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
+        secrets: inherit

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -6,4 +6,5 @@ on:
 jobs:
     label-new-prs:
         uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
-        secrets: inherit
+        secrets:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,10 +1,10 @@
 name: Contributor Responded
 on:
-    issue_comment:
-        types: [created, edited]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
-    check-for-response:
-        uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-for-response:
+    uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -4,7 +4,7 @@ on:
         types: [created, edited]
 
 jobs:
-    label-new-prs:
+    check-for-response:
         uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
         secrets:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -3,6 +3,11 @@ on:
     issue_comment:
         types: [created, edited]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
     check-for-response:
         uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline

--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   check-for-response:
     uses: OpenJobDescription/.github/.github/workflows/reusable_responded.yml@mainline
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -7,4 +7,5 @@ on:
 jobs:
     label-new-prs:
         uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
-        secrets: inherit
+        secrets:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 * * * *'
 
 jobs:
-    label-new-prs:
+    check-for-stales:
         uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
         secrets:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -7,5 +7,3 @@ on:
 jobs:
   check-for-stales:
     uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -1,0 +1,10 @@
+name: 'Check stale issues/PRs.'
+on: 
+  schedule:
+    # Run every hour on the hour
+    - cron: '0 * * * *'
+
+jobs:
+    label-new-prs:
+        uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
+        secrets: inherit

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 * * * *'
 
 jobs:
-    check-for-stales:
-        uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-for-stales:
+    uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -4,6 +4,11 @@ on:
     # Run every hour on the hour
     - cron: '0 * * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
     check-for-stales:
         uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -4,11 +4,6 @@ on:
     # Run every hour on the hour
     - cron: '0 * * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
-  contents: read
-
 jobs:
     check-for-stales:
         uses: OpenJobDescription/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

Need to standardize issue and PR management workflows across all repositories to automatically handle stale issues/PRs and contributor responses.

### What was the solution? (How)

Added two GitHub workflow files:
- `responded.yml` - Removes stale labels when contributors respond to issues/PRs
- `stale_prs_and_issues.yml` - Runs hourly to identify and label stale issues/PRs

Both workflows use reusable workflows from the organization's `.github` repository for consistency.

### What is the impact of this change?

- Automated stale issue/PR management
- Consistent labeling behavior across repositories
- Reduced manual maintenance overhead

### How was this change tested?

These workflows will be tested automatically when they trigger:
- `responded.yml` activates on issue comments
- `stale_prs_and_issues.yml` runs on hourly cron schedule

They have been tested in another repository here: 
* https://github.com/aws-deadline/deadline-cloud-for-blender/actions/runs/17332118916
  * https://github.com/aws-deadline/deadline-cloud-for-blender/issues/228

* https://github.com/aws-deadline/deadline-cloud-for-blender/actions/runs/17308632537
  * https://github.com/aws-deadline/deadline-cloud-for-blender/issues/268

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*