### PR TITLE
flx: handle `None` environments correctly

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1055,6 +1055,8 @@ class Environment(OpenJDModel_v2023_09):
     @model_validator(mode="before")
     @classmethod
     def _validate_has_script_or_variables(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(values, dict):
+            raise ValueError("Environment must be a mapping.")
         if values.get("script") is None and values.get("variables") is None:
             raise ValueError("Environment must have either a script or variables.")
         return values

--- a/test/openjd/model/v2023_09/test_environment_template.py
+++ b/test/openjd/model/v2023_09/test_environment_template.py
@@ -102,6 +102,14 @@ class TestEnvironmentTemplate:
                 1,
                 id="missing spec ver",
             ),
+            pytest.param(
+                {
+                    "specificationVersion": "environment-2023-09",
+                    "environment": None,
+                },
+                1,
+                id="environment is None",
+            ),
             #
             pytest.param(
                 {


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-model-for-python/issues/252

### What was the problem/requirement? (What/Why)
If a job template's environment was `None`, the library threw an unexpected exception.

### What was the solution? (How)
Catch this error and raise a ValueError properly.

### What is the impact of this change?
Prevents unexpected errors from this library

### How was this change tested?
Unit test

### Was this change documented?
n/a

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*