### PR TITLE
fix: allow minLength of 0 for strings and paths

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1363,8 +1363,8 @@ class JobStringParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
     def _validate_min_length(cls, value: Optional[int]) -> Optional[int]:
         if value is None:
             return value
-        if value <= 0:
-            raise ValueError("Required: 0 < minLength.")
+        if value < 0:
+            raise ValueError("Required: 0 <= minLength.")
         return value
 
     @field_validator("maxLength")
@@ -1607,8 +1607,8 @@ class JobPathParameterDefinition(OpenJDModel_v2023_09, JobParameterInterface):
     def _validate_min_length(cls, value: Optional[int]) -> Optional[int]:
         if value is None:
             return value
-        if value <= 0:
-            raise ValueError("Required: 0 < minLength.")
+        if value < 0:
+            raise ValueError("Required: 0 <= minLength.")
         return value
 
     @field_validator("maxLength")

--- a/test/openjd/model/v2023_09/test_job_parameters.py
+++ b/test/openjd/model/v2023_09/test_job_parameters.py
@@ -26,9 +26,7 @@ class TestJobStringParameterDefinition:
             pytest.param(
                 {"name": "Foo", "type": "STRING", "default": "some value"}, id="has default"
             ),
-            pytest.param(
-                {"name": "Foo", "type": "STRING", "minLength": 1}, id="smallest min length"
-            ),
+            pytest.param({"name": "Foo", "type": "STRING", "minLength": 0}, id="minLength zero"),
             pytest.param(
                 {"name": "Foo", "type": "STRING", "maxLength": 1}, id="smallest max length"
             ),
@@ -215,7 +213,9 @@ class TestJobStringParameterDefinition:
                 id="allowedValues item not string",
             ),
             #
-            pytest.param({"name": "Foo", "type": "STRING", "minLength": 0}, id="0 < min"),
+            pytest.param(
+                {"name": "Foo", "type": "STRING", "minLength": -1}, id="negative minLength"
+            ),
             pytest.param({"name": "Foo", "type": "STRING", "maxLength": 0}, id="0 < max"),
             pytest.param(
                 {"name": "Foo", "type": "STRING", "minLength": 2, "maxLength": 1}, id="min > max"
@@ -495,7 +495,7 @@ class TestJobPathParameterDefinition:
             pytest.param(
                 {"name": "Foo", "type": "PATH", "default": "some value"}, id="has default"
             ),
-            pytest.param({"name": "Foo", "type": "PATH", "minLength": 1}, id="smallest min length"),
+            pytest.param({"name": "Foo", "type": "PATH", "minLength": 0}, id="minLength zero"),
             pytest.param({"name": "Foo", "type": "PATH", "maxLength": 1}, id="smallest max length"),
             pytest.param(
                 {"name": "Foo", "type": "PATH", "allowedValues": ["a"]}, id="has allowedValues"
@@ -709,7 +709,7 @@ class TestJobPathParameterDefinition:
                 id="allowedValues item not string",
             ),
             #
-            pytest.param({"name": "Foo", "type": "PATH", "minLength": 0}, id="0 < min"),
+            pytest.param({"name": "Foo", "type": "PATH", "minLength": -1}, id="negative minLength"),
             pytest.param({"name": "Foo", "type": "PATH", "maxLength": 0}, id="0 < max"),
             pytest.param(
                 {"name": "Foo", "type": "PATH", "minLength": 2, "maxLength": 1}, id="min > max"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The OpenJD spec does not require minLength to be greater than 0, but this package does.

Spec reference: [2023-09-Template-Schemas.md §2.1](https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#21-jobstringparameterdefinition)

### What was the solution? (How)
Fix it. 

### What is the impact of this change?

### How was this change tested?
Added unit tests. Also passes the tests in the conformance test suite: https://github.com/OpenJobDescription/openjd-specifications/pull/103

### Was this change documented?
n/a

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*