### PR TITLE
fix: reject control characters in job names

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -203,6 +203,8 @@ class JobTemplateName(FormatString):
     _min_length = 1
     # Max length is validated after resolution in Job model, not here
     # because the template name can contain format strings
+    # All unicode except the [Cc] (control characters) category
+    _regex = f"(?-m:^[^{_Cc_characters}]+\\Z)"
 
     def __new__(cls, value: str, *, context: ModelParsingContextInterface = ModelParsingContext()):
         return super().__new__(cls, value, context=context)

--- a/test/openjd/model/v2023_09/test_job_template.py
+++ b/test/openjd/model/v2023_09/test_job_template.py
@@ -197,6 +197,33 @@ class TestJobTemplate:
             ),
             pytest.param(
                 {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Job\x1fName",
+                    "steps": [STEP_TEMPLATE],
+                },
+                1,
+                id="name with control char 0x1F",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Job\x7fName",
+                    "steps": [STEP_TEMPLATE],
+                },
+                1,
+                id="name with control char 0x7F",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Job\x9fName",
+                    "steps": [STEP_TEMPLATE],
+                },
+                1,
+                id="name with control char 0x9F",
+            ),
+            pytest.param(
+                {
                     "name": "Foo",
                     "steps": [STEP_TEMPLATE],
                 },

--- a/test/openjd/model/v2023_09/test_job_template.py
+++ b/test/openjd/model/v2023_09/test_job_template.py
@@ -224,6 +224,24 @@ class TestJobTemplate:
             ),
             pytest.param(
                 {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "JobName\n",
+                    "steps": [STEP_TEMPLATE],
+                },
+                1,
+                id="name with trailing newline",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Job\nName",
+                    "steps": [STEP_TEMPLATE],
+                },
+                1,
+                id="name with embedded newline",
+            ),
+            pytest.param(
+                {
                     "name": "Foo",
                     "steps": [STEP_TEMPLATE],
                 },


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The spec bans control characters in job names, but this package allowed them.

Spec reference: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#111-jobname

### What was the solution? (How)
Add a regex to reject them. 

### What is the impact of this change?

### How was this change tested?
Add unit tests. Also by running the conformance tests against the changes: https://github.com/OpenJobDescription/openjd-specifications/pull/103

### Was this change documented?
n/a

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*