### PR TITLE
fix: reject path separators in embedded filenames

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -509,6 +509,10 @@ class EmbeddedFileText(OpenJDModel_v2023_09):
     def _validate_filename(cls, v: Optional[Filename], info: ValidationInfo) -> Optional[Filename]:
         if v is None:
             return v
+        if "/" in v or "\\" in v:
+            raise ValueError(
+                "filename must be a basename only and cannot contain path separators ('/' or '\\\\')"
+            )
         context = cast(Optional[ModelParsingContext], info.context)
         max_len = 256 if context and "FEATURE_BUNDLE_1" in context.extensions else 64
         if len(v) > max_len:

--- a/test/openjd/model/v2023_09/test_embedded.py
+++ b/test/openjd/model/v2023_09/test_embedded.py
@@ -63,7 +63,14 @@ class TestEmbeddedFileText:
                 {"name": "foo", "type": "TEXT", "data": "some text", "runnable": "True"},
                 id="runnable must be bool",
             ),
-            # TODO - tests for filename allowed characters
+            pytest.param(
+                {"name": "foo", "type": "TEXT", "data": "some text", "filename": "dir/file.txt"},
+                id="filename with forward slash",
+            ),
+            pytest.param(
+                {"name": "foo", "type": "TEXT", "data": "some text", "filename": "dir\\file.txt"},
+                id="filename with backslash",
+            ),
         ),
     )
     def test_parse_fails(self, data: dict[str, Any]) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Spec says embedded filenames should not contain path separators, but this package allows them.

[§6.1 `<EmbeddedFileText>`](https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#61-embeddedfiletext)

### What was the solution? (How)
Fix the validator.

### What is the impact of this change?
Embedded filenames are correctly validated.

### How was this change tested?
Added unit tests and ran against the conformance test suite: https://github.com/OpenJobDescription/openjd-specifications/pull/103

### Was this change documented?
n/a

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*