### PR TITLE
fix!: require attribute and amount names to be unique

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -2579,7 +2579,7 @@ class HostRequirementsTemplate(OpenJDModel_v2023_09):
             return v
         if len(v) == 0:
             raise ValueError("List must contain at least one element or not be defined.")
-        return v
+        return validate_unique_elements(v, item_value=lambda v: v.name.lower(), property="name")
 
     @field_validator("attributes")
     @classmethod
@@ -2590,7 +2590,7 @@ class HostRequirementsTemplate(OpenJDModel_v2023_09):
             return v
         if len(v) == 0:
             raise ValueError("List must contain at least one element or not be defined.")
-        return v
+        return validate_unique_elements(v, item_value=lambda v: v.name.lower(), property="name")
 
     @model_validator(mode="after")
     def _validate(self) -> Self:

--- a/test/openjd/model/v2023_09/test_step_host_requirements.py
+++ b/test/openjd/model/v2023_09/test_step_host_requirements.py
@@ -457,24 +457,26 @@ class TestHostRequirementsTemplate:
         # no exception was raised.
 
     @pytest.mark.parametrize(
-        "data,error_count",
+        "data,error_count,error_loc",
         [
-            pytest.param({}, 1, id="missing amounts & attributes"),
-            pytest.param({"unknown": "value"}, 1, id="unknown field"),
-            pytest.param({"amounts": []}, 1, id="too few amounts"),
-            pytest.param({"attributes": []}, 1, id="too few attributes"),
+            pytest.param({}, 1, (), id="missing amounts & attributes"),
+            pytest.param({"unknown": "value"}, 1, ("unknown",), id="unknown field"),
+            pytest.param({"amounts": []}, 1, ("amounts",), id="too few amounts"),
+            pytest.param({"attributes": []}, 1, ("attributes",), id="too few attributes"),
             pytest.param(
                 {"amounts": [{"name": f"amount.mycap{i}", "min": 1} for i in range(0, 51)]},
                 1,
+                (),
                 id="too many as only amounts",
             ),
             pytest.param(
                 {
                     "attributes": [
-                        {"name": f"attr.mycap{i}|", "anyOf": ["foo"]} for i in range(0, 51)
+                        {"name": f"attr.mycap{i}", "anyOf": ["foo"]} for i in range(0, 51)
                     ]
                 },
                 1,
+                (),
                 id="too many as only attributes",
             ),
             pytest.param(
@@ -485,16 +487,66 @@ class TestHostRequirementsTemplate:
                     ],
                 },
                 1,
+                (),
                 id="too many as combination",
+            ),
+            pytest.param(
+                {
+                    "amounts": [
+                        {"name": "amount.mycap", "min": 1},
+                        {"name": "amount.mycap", "min": 2},
+                    ]
+                },
+                1,
+                ("amounts",),
+                id="duplicate amount names",
+            ),
+            pytest.param(
+                {
+                    "amounts": [
+                        {"name": "amount.mycap", "min": 1},
+                        {"name": "amount.MYCAP", "min": 2},
+                    ]
+                },
+                1,
+                ("amounts",),
+                id="duplicate amount names case insensitive",
+            ),
+            pytest.param(
+                {
+                    "attributes": [
+                        {"name": "attr.mycap", "anyOf": ["foo"]},
+                        {"name": "attr.mycap", "anyOf": ["bar"]},
+                    ]
+                },
+                1,
+                ("attributes",),
+                id="duplicate attribute names",
+            ),
+            pytest.param(
+                {
+                    "attributes": [
+                        {"name": "attr.mycap", "anyOf": ["foo"]},
+                        {"name": "attr.MYCAP", "anyOf": ["bar"]},
+                    ]
+                },
+                1,
+                ("attributes",),
+                id="duplicate attribute names case insensitive",
             ),
         ],
     )
-    def test_parse_fails(self, data: dict[str, Any], error_count: int) -> None:
-        # Failure case testing for Open Job Description AmountRequirementTemplate.
+    def test_parse_fails(self, data: dict[str, Any], error_count: int, error_loc: tuple) -> None:
+        # Failure case testing for Open Job Description HostRequirementsTemplate.
 
         # WHEN
         with pytest.raises(ValidationError) as excinfo:
-            _parse_model(model=AmountRequirementTemplate, obj=data)
+            _parse_model(model=HostRequirementsTemplate, obj=data)
 
         # THEN
         assert len(excinfo.value.errors()) == error_count, str(excinfo.value)
+        if error_loc:
+            actual_loc = excinfo.value.errors()[0]["loc"]
+            assert (
+                actual_loc[: len(error_loc)] == error_loc
+            ), f"Expected {error_loc}, got {actual_loc}"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The amount and attribute names in host requirements are not required to be unique at the moment; duplicate names are allowed. Multiple requirements with the same name is non-sensical though and should be rejected.

Related OpenJD spec PR: https://github.com/OpenJobDescription/openjd-specifications/pull/110

While updating the test, I noticed existing test was incorrectly set up and testing the wrong data model. Since the test just looked for failures, the test passed but the validation failures were for the wrong reason. I made the test more specific to ensure it's testing what we think we're testing.

There are other tests that make similar mistakes and will also need to be updated. Future work.

### What was the solution? (How)
Reject a template if a step's host requirements has duplicated attribute or amount names.

### What is the impact of this change?
Closes a undefined behavior gap.

### How was this change tested?
Unit tests

### Was this change documented?
n/a

### Is this a breaking change?
Technically yes, but practically no. Duplicated requirements do not have a clear behavior, and templates with duplicates are likely buggy. Marking the PR with `fix!` to indicate a minor version bump is recommended.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*