### PR TITLE
fix: enforce maximum of 1024 items in range expressions

### DIFF
--- a/src/openjd/model/_range_expr.py
+++ b/src/openjd/model/_range_expr.py
@@ -150,6 +150,10 @@ class IntRangeExpr(Sized):
 
     def _validate(self) -> None:
         """raises: ValueError - if not valid"""
+        if len(self) > 1024:
+            raise ValueError(
+                f"Range expression produces {len(self)} values, but the maximum is 1024."
+            )
         # Validate that the ranges are not overlapping
         prev_range: IntRange | None = None
         for range_ in self.ranges:

--- a/test/openjd/model/_internal/test_range_expr.py
+++ b/test/openjd/model/_internal/test_range_expr.py
@@ -362,6 +362,30 @@ class TestIntRangeExpr:
         assert -3 not in IntRangeExpr.from_str("-1--2:-1")
         assert 0 not in IntRangeExpr.from_str("-1--2:-1")
 
+    def test_range_expr_max_1024_items_succeeds(self):
+        expr = IntRangeExpr.from_str("1-1024")
+        assert len(expr) == 1024
+
+    def test_range_expr_1025_items_fails(self):
+        with pytest.raises(ExpressionError):
+            IntRangeExpr.from_str("1-1025")
+
+    def test_range_expr_combined_subranges_exceed_1024_fails(self):
+        with pytest.raises(ExpressionError):
+            IntRangeExpr.from_str("1-600,700-1300")
+
+    def test_range_expr_stepped_within_limit_succeeds(self):
+        expr = IntRangeExpr.from_str("1-2047:2")
+        assert len(expr) == 1024
+
+    def test_range_expr_stepped_exceeds_limit_fails(self):
+        with pytest.raises(ExpressionError):
+            IntRangeExpr.from_str("1-3000:2")
+
+    def test_range_expr_negative_range_exceeds_limit_fails(self):
+        with pytest.raises(ExpressionError):
+            IntRangeExpr.from_str("-512-512")
+
 
 class TestIntRange:
     def test_length(self):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Range expressions should only allow 1024 items, but this package doesn't enforce the limit.

https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#3411-inttaskparameterdefinition

### What was the solution? (How)
Enforce the limit.

### What is the impact of this change?
Library matches spec closer.

### How was this change tested?
Unit tests

### Was this change documented?
n/a

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*