### PR TITLE
chore(build): build wheels for multiple platforms

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -35,57 +35,36 @@ jobs:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
   PreRelease:
-      needs: [TagRelease, UnitTests]
-      uses: OpenJobDescription/.github/.github/workflows/reusable_prerelease.yml@mainline
-      permissions:
-        id-token: write
-        contents: write
-      secrets: inherit
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
-
-  Release:
-      needs: [TagRelease, PreRelease]
-      uses: OpenJobDescription/.github/.github/workflows/reusable_release.yml@mainline
-      secrets: inherit
-      permissions:
-        id-token: write
-        contents: write
-      with:
-          tag: ${{ needs.TagRelease.outputs.tag }}
-
-  Publish:
-    needs: [TagRelease, Release]
-    uses: OpenJobDescription/.github/.github/workflows/reusable_publish_python.yml@mainline
-    permissions:
-      id-token: write
+    needs: [TagRelease, UnitTests]
+    uses: OpenJobDescription/.github/.github/workflows/reusable_maturin_prerelease.yml@mainline
     secrets: inherit
     with:
-        tag: ${{ needs.TagRelease.outputs.tag }}
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  Release:
+    needs: [TagRelease, PreRelease]
+    uses: OpenJobDescription/.github/.github/workflows/reusable_release.yml@mainline
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
 
   # PyPI does not support reusable workflows yet
-  # # See https://github.com/pypi/warehouse/issues/11096
+  # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:
-    needs: [TagRelease, Publish]
+    needs: [TagRelease, Release, PreRelease]
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
         with:
-          ref: ${{ needs.TagRelease.outputs.tag }}
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.9'
-      - name: Install dependencies
-        run: |
-          pip install --upgrade hatch "virtualenv<21"
-      - name: Build
-        run: hatch -v build
-      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+          name: build-artifact
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/_build_backend.py
+++ b/_build_backend.py
@@ -32,9 +32,16 @@ direct commands. Either path produces wheels with the VCS version.
 from __future__ import annotations
 
 import contextlib
+import os
 import shutil
 import sys
 from pathlib import Path
+
+# Windows MSVC linker fails with LNK1104 when paths exceed MAX_PATH (260 chars).
+# Building from an extracted sdist produces deeply nested target directories.
+# Redirect Cargo's output to a short path to avoid this.
+if sys.platform == "win32" and "CARGO_TARGET_DIR" not in os.environ:
+    os.environ["CARGO_TARGET_DIR"] = "C:\\cargo-target"
 
 import maturin
 

--- a/scripts/maturin_build.py
+++ b/scripts/maturin_build.py
@@ -67,6 +67,17 @@ def main(argv: list[str]) -> int:
         )
         shutil.move(str(PYPROJECT_BAK), str(PYPROJECT))
 
+    # --version-only: inject the VCS version into pyproject.toml and
+    # _version.py without running maturin. Used in CI when maturin-action
+    # handles the actual build but needs the version patched beforehand.
+    if "--version-only" in argv:
+        version = compute_version()
+        write_version_file(version)
+        print(f"Wrote src/openjd/model/_version.py (version {version})")
+        _patch_pyproject(version)
+        print(f"Patched pyproject.toml: project.version = {version!r}")
+        return 0
+
     maturin_args = argv or ["develop"]
 
     version = compute_version()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The package now contains a native Rust extension (PyO3 bindings). Previously, `openjd-model` was pure Python and a single `py3-none-any` wheel worked on all platforms. With native code, we need to build and publish one wheel per platform so that pip install works without requiring a Rust toolchain on the target machine.

### What was the solution? (How)

Update the GitHub release workflow to use `maturin` to build wheels on each target platform (Mac, Windows, Linux, on both x86_64 and ARM architectures).

Reusable workflows are being added to the `.github` repo in this PR (will be reused in openjd-sessions as well): https://github.com/OpenJobDescription/.github/pull/17

### What is the impact of this change?

Starting from the next release, we will have platform specific wheels published to PyPI. `pip install openjd-model` will resolve a pre-built native wheel on all supported platforms. Users no longer need a Rust toolchain to install the package on Windows, macOS, or Linux.

### How was this change tested?

Made a test branch that runs the multi platform build and downloads the artifacts and shows they are in the correct folder layout as expected: https://github.com/jericht/openjd-model-for-python/actions/runs/27854658792
- Builds the wheel on all platforms
- Prints out the resulting artifact layout (for consumption by [reusable_release.yml](https://github.com/OpenJobDescription/.github/blob/068576217f4d861cf4b3ae7245275478b5bf077f/.github/workflows/reusable_release.yml))
- Installs the wheel and imports both the Python module and Rust modules from Python on all platforms

Output from above run:

```
=== build-artifact layout ===
build-artifact/
└── dist
    ├── openjd_model-0.0.1-cp39-abi3-macosx_10_12_x86_64.whl
    ├── openjd_model-0.0.1-cp39-abi3-macosx_11_0_arm64.whl
    ├── openjd_model-0.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
    ├── openjd_model-0.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
    ├── openjd_model-0.0.1-cp39-abi3-win_amd64.whl
    ├── openjd_model-0.0.1-cp39-abi3-win_arm64.whl
    └── openjd_model-0.9.0.tar.gz

2 directories, 7 files

=== file details ===
total 27224
drwxr-xr-x 2 runner runner    4096 Jun 18 22:07 .
drwxr-xr-x 3 runner runner    4096 Jun 18 22:07 ..
-rw-r--r-- 1 runner runner 4704132 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-macosx_10_12_x86_64.whl
-rw-r--r-- 1 runner runner 4546002 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-macosx_11_0_arm64.whl
-rw-r--r-- 1 runner runner 4881124 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-rw-r--r-- 1 runner runner 4939740 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r-- 1 runner runner 4409145 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-win_amd64.whl
-rw-r--r-- 1 runner runner 4166130 Jun 18 22:07 openjd_model-0.0.1-cp39-abi3-win_arm64.whl
-rw-r--r-- 1 runner runner  209662 Jun 18 22:07 openjd_model-0.9.0.tar.gz
```

Example verification on Windows runner:

```
  python -c "
  from openjd.model._version import version
  print(f'openjd-model version: {version}')
  
  from openjd._openjd_rs import FormatString
  print(f'Native extension loaded: FormatString={FormatString}')
  
  from openjd.model import parse_model
  print('parse_model imported successfully')
  
  import platform
  print(f'Platform: {platform.system()} {platform.machine()}')
  print('ALL CHECKS PASSED')
  "
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.13.14\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.13.14\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.14\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.14\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.13.14\x64
openjd-model version: 0.0.1
Native extension loaded: FormatString=<class 'openjd.expr.FormatString'>
parse_model imported successfully
Platform: Windows AMD64
ALL CHECKS PASSED
```

### Was this change documented?

N/A

### Is this a breaking change?

No.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*