### PR TITLE
chore(release): fix download path for PublishToPyPI step

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -63,7 +63,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: build-artifact
-          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I fixed the GitHub release, but now the PublishToPyPI step is failing: https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/28205044422/job/83555345059

Root cause is that the artifacts are downloaded into `dist/dist` folder, and the double dist folder is causing the PyPI publish to not see the artifacts

### What was the solution? (How)

Remove the redundant dist folder

### What is the impact of this change?

PublishToPyPI works

### How was this change tested?

N/A - this download-artifacts call matches the one in `reusable_release.yml`, which we confirmed works in the above workflow: (see [source code](https://github.com/OpenJobDescription/.github/blob/8c60f75cf0d9102c960067319149e10e35469946/.github/workflows/reusable_release.yml#L32-L33))

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*