### PR TITLE
chore: including missing LICENSE and NOTICE files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ features = ["extension-module"]
 #   These only need to be in the sdist; they're build-time
 #   tooling, not runtime code.
 include = [
+    { path = ".gitignore", format = "sdist" },
+    { path = "LICENSE", format = "sdist" },
+    { path = "NOTICE", format = "sdist" },
     "src/openjd/model/_version.py",
     { path = "_build_backend.py", format = "sdist" },
     { path = "scripts/generate_version.py", format = "sdist" },


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The 0.10.1 release had a failure publishing the sdist to PyPI because of a missing LICENSE file https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/28206698598

### What was the solution? (How)
Add the LICENSE file as well as NOTICE and .gitignore files back into the sdist, which matches the contents of the old sdist generated by `hatch build`

### What is the impact of this change?
PublishToPyPI will successfully publish sdist

### How was this change tested?

Built the sdist and uploaded to TestPyPI: https://test.pypi.org/project/openjd-model/0.10.2/#files

Compared the sdist generated by the old hatch build system (94129dc2b8744e780183eff25e0b932561420ddf) and the one generated by the new build system

Command
```
diff -rq /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b /tmp/sdist-new/openjd_model-*
```

Output
```
📦 Including files matching "_build_backend.py"
📦 Including files matching "scripts/generate_version.py"
📦 Built source distribution to /home/jericht/.workspace/openjd-new/dist/openjd_model-0.9.0.tar.gz
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/.gitignore and /tmp/sdist-new/openjd_model-0.9.0/.gitignore differ
Only in /tmp/sdist-new/openjd_model-0.9.0: Cargo.lock
Only in /tmp/sdist-new/openjd_model-0.9.0: Cargo.toml
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/PKG-INFO and /tmp/sdist-new/openjd_model-0.9.0/PKG-INFO differ
Only in /tmp/sdist-new/openjd_model-0.9.0: _build_backend.py
Only in /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b: _version.py
Only in /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b: hatch.toml
Only in /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b: hatch_version_hook.py
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/pyproject.toml and /tmp/sdist-new/openjd_model-0.9.0/pyproject.toml differ
Only in /tmp/sdist-new/openjd_model-0.9.0: rust-bindings
Only in /tmp/sdist-new/openjd_model-0.9.0: scripts
Only in /tmp/sdist-new/openjd_model-0.9.0/src/openjd: _openjd_rs.pyi
Only in /tmp/sdist-new/openjd_model-0.9.0/src/openjd: expr
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/src/openjd/model/_format_strings/_format_string.py and /tmp/sdist-new/openjd_model-0.9.0/src/openjd/model/_format_strings/_format_string.py differ
Only in /tmp/sdist-new/openjd_model-0.9.0/src/openjd/model: _v1
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/src/openjd/model/_version.py and /tmp/sdist-new/openjd_model-0.9.0/src/openjd/model/_version.py differ
Only in /tmp/sdist-new/openjd_model-0.9.0/src/openjd/model: v0
Files /tmp/sdist-old/openjd_model-0.9.1.post9+g94129dc2b/src/openjd/model/v2023_09/_model.py and /tmp/sdist-new/openjd_model-0.9.0/src/openjd/model/v2023_09/_model.py differ
```

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*