### PR TITLE
chore: rename YamlLoader to SafeLoader

### DIFF
--- a/test/openjd/model_v0/benchmark/test_yaml_loader_performance.py
+++ b/test/openjd/model_v0/benchmark/test_yaml_loader_performance.py
@@ -164,17 +164,17 @@ steps:
         # Select the appropriate loader directly
         if loader_type == "CSafeLoader":
             try:
-                from yaml import CSafeLoader as YamlLoader  # type: ignore[attr-defined]
+                from yaml import CSafeLoader as SafeLoader  # type: ignore[attr-defined]
             except ImportError:
-                from yaml import SafeLoader as YamlLoader  # type: ignore[assignment]
+                from yaml import SafeLoader  # type: ignore[assignment]
         else:
-            from yaml import SafeLoader as YamlLoader  # type: ignore[assignment]
+            from yaml import SafeLoader  # type: ignore[assignment]
 
         for _ in range(iterations):
             start_time = time.perf_counter()
             # Parse YAML directly instead of using document_string_to_object
             # to avoid the module-level loader selection
-            yaml.load(template_content, Loader=YamlLoader)
+            yaml.load(template_content, Loader=SafeLoader)
             end_time = time.perf_counter()
             times.append((end_time - start_time) * 1000)  # Convert to milliseconds
 

--- a/test/openjd/model_v1/benchmark/test_yaml_loader_performance.py
+++ b/test/openjd/model_v1/benchmark/test_yaml_loader_performance.py
@@ -164,17 +164,17 @@ steps:
         # Select the appropriate loader directly
         if loader_type == "CSafeLoader":
             try:
-                from yaml import CSafeLoader as YamlLoader  # type: ignore[attr-defined]
+                from yaml import CSafeLoader as SafeLoader  # type: ignore[attr-defined]
             except ImportError:
-                from yaml import SafeLoader as YamlLoader  # type: ignore[assignment]
+                from yaml import SafeLoader  # type: ignore[assignment]
         else:
-            from yaml import SafeLoader as YamlLoader  # type: ignore[assignment]
+            from yaml import SafeLoader  # type: ignore[assignment]
 
         for _ in range(iterations):
             start_time = time.perf_counter()
             # Parse YAML directly instead of using document_string_to_object
             # to avoid the module-level loader selection
-            yaml.load(template_content, Loader=YamlLoader)
+            yaml.load(template_content, Loader=SafeLoader)
             end_time = time.perf_counter()
             times.append((end_time - start_time) * 1000)  # Convert to milliseconds
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Scanner flagging yaml.load instead of yaml.safe_load.

### What was the solution? (How)

safe_load does what we do, but we also allow the c-extension if it exists: https://github.com/yaml/pyyaml/blob/34a9bf82357f4952d8f194a5a31f1c39743652d0/lib/yaml/__init__.py#L125

Probably won't stop it, but changed the import aliases to reflect we're using SafeLoader regardless of c-extension.

### What is the impact of this change?

Scanner reports reduced.

### How was this change tested?

```
hatch run fmt
hatch run lint
```

### Was this change documented?

N/A
### Is this a breaking change?
N/a

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*