### PR TITLE
feat!: bump openjd crates for EXPR and WRAP_ACTIONS extension support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-model"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f903c48ac92c4a0d57edb94af16a4e9772caba56ec3e62fd303ca793121912"
+checksum = "dfe8867627c211bc704c9a8d94f16b32bc4b184b96560ae1ed2af24522965677"
 dependencies = [
  "indexmap",
  "openjd-expr",
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-sessions"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b04342d2b4a1cef0e5ca803c3b1423c278e3d169367b96791d02ae33c8a530d"
+checksum = "5a6afe6534a84e47e19ef834d78bf9715e578202b343454f258f2792e08fe503"
 dependencies = [
  "bitflags",
  "futures-util",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.26"
+version = "0.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
 dependencies = [
  "ahash",
  "annotate-snippets",

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -2522,13 +2522,13 @@ limitations under the License.
 ** arraydeque; version 0.5.1 -- https://crates.io/crates/arraydeque
 ** get-size-derive2; version 0.7.4 -- https://crates.io/crates/get-size-derive2
 ** get-size2; version 0.7.4 -- https://crates.io/crates/get-size2
-** granit-parser; version 0.0.2 -- https://crates.io/crates/granit-parser
+** granit-parser; version 0.0.3 -- https://crates.io/crates/granit-parser
 ** itoa; version 1.0.18 -- https://crates.io/crates/itoa
 ** libc; version 0.2.186 -- https://crates.io/crates/libc
 ** manyhow-macros; version 0.11.4 -- https://crates.io/crates/manyhow-macros
 ** openjd-expr; version 0.1.2 -- https://crates.io/crates/openjd-expr
-** openjd-model; version 0.2.1 -- https://crates.io/crates/openjd-model
-** openjd-sessions; version 0.2.3 -- https://crates.io/crates/openjd-sessions
+** openjd-model; version 0.3.0 -- https://crates.io/crates/openjd-model
+** openjd-sessions; version 0.3.1 -- https://crates.io/crates/openjd-sessions
 ** pin-project-lite; version 0.2.17 -- https://crates.io/crates/pin-project-lite
 ** portable-atomic; version 1.13.1 -- https://crates.io/crates/portable-atomic
 ** proc-macro2; version 1.0.106 -- https://crates.io/crates/proc-macro2
@@ -2542,7 +2542,7 @@ limitations under the License.
 ** rustc-hash; version 2.1.2 -- https://crates.io/crates/rustc-hash
 ** rustversion; version 1.0.22 -- https://crates.io/crates/rustversion
 ** ryu; version 1.0.23 -- https://crates.io/crates/ryu
-** serde-saphyr; version 0.0.26 -- https://crates.io/crates/serde-saphyr
+** serde-saphyr; version 0.0.27 -- https://crates.io/crates/serde-saphyr
 ** serde; version 1.0.228 -- https://crates.io/crates/serde
 ** serde_core; version 1.0.228 -- https://crates.io/crates/serde_core
 ** serde_derive; version 1.0.228 -- https://crates.io/crates/serde_derive

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 openjd-expr = "0.1.2"
-openjd-model = "0.2.1"
-openjd-sessions = "0.2.3"
+openjd-model = "0.3.0"
+openjd-sessions = "0.3.1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"

--- a/rust-bindings/src/model/template_types.rs
+++ b/rust-bindings/src/model/template_types.rs
@@ -325,17 +325,30 @@ impl PyEnvironmentActions {
     /// schema. If both flavours of the same field are passed, the
     /// snake-case form wins.
     #[new]
-    #[pyo3(signature = (*, on_enter=None, on_exit=None, onEnter=None, onExit=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, on_enter=None, on_exit=None, on_wrap_env_enter=None, on_wrap_task_run=None, on_wrap_env_exit=None, onEnter=None, onExit=None, onWrapEnvEnter=None, onWrapTaskRun=None, onWrapEnvExit=None))]
     fn new(
         on_enter: Option<PyAction>,
         on_exit: Option<PyAction>,
+        on_wrap_env_enter: Option<PyAction>,
+        on_wrap_task_run: Option<PyAction>,
+        on_wrap_env_exit: Option<PyAction>,
         #[allow(non_snake_case)] onEnter: Option<PyAction>,
         #[allow(non_snake_case)] onExit: Option<PyAction>,
+        #[allow(non_snake_case)] onWrapEnvEnter: Option<PyAction>,
+        #[allow(non_snake_case)] onWrapTaskRun: Option<PyAction>,
+        #[allow(non_snake_case)] onWrapEnvExit: Option<PyAction>,
     ) -> Self {
         let on_enter = on_enter.or(onEnter);
         let on_exit = on_exit.or(onExit);
+        let on_wrap_env_enter = on_wrap_env_enter.or(onWrapEnvEnter);
+        let on_wrap_task_run = on_wrap_task_run.or(onWrapTaskRun);
+        let on_wrap_env_exit = on_wrap_env_exit.or(onWrapEnvExit);
         PyEnvironmentActions {
             inner: EnvironmentActions {
+                on_wrap_env_enter: on_wrap_env_enter.map(|a| a.inner),
+                on_wrap_task_run: on_wrap_task_run.map(|a| a.inner),
+                on_wrap_env_exit: on_wrap_env_exit.map(|a| a.inner),
                 on_enter: on_enter.map(|a| a.inner),
                 on_exit: on_exit.map(|a| a.inner),
             },
@@ -370,6 +383,48 @@ impl PyEnvironmentActions {
         self.on_exit()
     }
 
+    #[getter]
+    fn on_wrap_env_enter(&self) -> Option<PyAction> {
+        self.inner
+            .on_wrap_env_enter
+            .as_ref()
+            .map(|a| PyAction { inner: a.clone() })
+    }
+
+    #[getter]
+    #[pyo3(name = "onWrapEnvEnter")]
+    fn on_wrap_env_enter_camel(&self) -> Option<PyAction> {
+        self.on_wrap_env_enter()
+    }
+
+    #[getter]
+    fn on_wrap_task_run(&self) -> Option<PyAction> {
+        self.inner
+            .on_wrap_task_run
+            .as_ref()
+            .map(|a| PyAction { inner: a.clone() })
+    }
+
+    #[getter]
+    #[pyo3(name = "onWrapTaskRun")]
+    fn on_wrap_task_run_camel(&self) -> Option<PyAction> {
+        self.on_wrap_task_run()
+    }
+
+    #[getter]
+    fn on_wrap_env_exit(&self) -> Option<PyAction> {
+        self.inner
+            .on_wrap_env_exit
+            .as_ref()
+            .map(|a| PyAction { inner: a.clone() })
+    }
+
+    #[getter]
+    #[pyo3(name = "onWrapEnvExit")]
+    fn on_wrap_env_exit_camel(&self) -> Option<PyAction> {
+        self.on_wrap_env_exit()
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "EnvironmentActions(on_enter={}, on_exit={})",
@@ -397,6 +452,15 @@ impl PyEnvironmentActions {
         }
         if let Some(a) = slf.on_exit() {
             kwargs.set_item("on_exit", a)?;
+        }
+        if let Some(a) = slf.on_wrap_env_enter() {
+            kwargs.set_item("on_wrap_env_enter", a)?;
+        }
+        if let Some(a) = slf.on_wrap_task_run() {
+            kwargs.set_item("on_wrap_task_run", a)?;
+        }
+        if let Some(a) = slf.on_wrap_env_exit() {
+            kwargs.set_item("on_wrap_env_exit", a)?;
         }
         let cls = py.get_type::<PyEnvironmentActions>();
         let args = PyTuple::new(py, [cls.into_any(), kwargs.into_any()])?;

--- a/rust-bindings/src/sessions/session.rs
+++ b/rust-bindings/src/sessions/session.rs
@@ -539,15 +539,20 @@ impl PySession {
     }
 
     /// Run a task. Non-blocking — spawns the onRun action on a background thread.
-    #[pyo3(signature = (*, step_script, task_parameter_values=None, resolved_symtab=None, os_env_vars=None))]
+    ///
+    /// `step_name` is surfaced as `WrappedStep.Name` to a wrapping environment's
+    /// `onWrapTaskRun` hook (RFC 0008).
+    #[pyo3(signature = (*, step_script, step_name="", task_parameter_values=None, resolved_symtab=None, os_env_vars=None))]
     fn run_task(
         &self,
         step_script: &PyStepScript,
+        step_name: &str,
         task_parameter_values: Option<&Bound<'_, PyDict>>,
         resolved_symtab: Option<&crate::expr::PySerializedSymbolTable>,
         os_env_vars: Option<HashMap<String, String>>,
     ) -> PyResult<()> {
         let script = step_script.inner.clone();
+        let step_name = step_name.to_owned();
         let task_params = match task_parameter_values {
             Some(d) => Some(extract_task_parameter_values(d)?),
             None => None,
@@ -573,8 +578,13 @@ impl PySession {
             run_action(session, session_arc, snapshot, move |rt, session| {
                 let env_ref = os_env_vars.as_ref();
                 let task_ref = task_params.as_ref();
-                let _ =
-                    rt.block_on(session.run_task(&script, task_ref, resolved.as_ref(), env_ref));
+                let _ = rt.block_on(session.run_task(
+                    &step_name,
+                    &script,
+                    task_ref,
+                    resolved.as_ref(),
+                    env_ref,
+                ));
             });
         });
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

New versions of openjd-sessions and openjd-model crates are available that implement the EXPR and WRAP_ACTIONS extensions. We need to consume them in this package too

### What was the solution? (How)

Update dependencies and updated rust bindings with the breaking changes

### What is the impact of this change?

We have updated openjd-sessions and openjd-model crates with EXPR and WRAP_ACTIONS changes and corresponding rust bindings updates

### How was this change tested?

hatch run lint && hatch run test

### Was this change documented?

No

### Is this a breaking change?

Yes, the rust bindings have a new required field for `run_task`, step name as part of the update

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*