### PR TITLE
fix: deliver mid-action cancels through SessionCancelHandle

### DIFF
--- a/rust-bindings/src/sessions/session.rs
+++ b/rust-bindings/src/sessions/session.rs
@@ -265,6 +265,11 @@ pub(crate) struct PySession {
     session: Arc<Mutex<Option<Session>>>,
     /// Snapshot updated after each state change, readable without blocking on the session.
     snapshot: Arc<Mutex<StateSnapshot>>,
+    /// Thread-safe cancel handle, obtained at construction. Delivers a cancel
+    /// to whichever action is running even while the `Session` value is owned
+    /// by a background action thread — the case where `Session::cancel_action`
+    /// is unreachable (it needs `&mut Session`).
+    cancel_handle: openjd_sessions::session::SessionCancelHandle,
 }
 
 impl PySession {
@@ -360,9 +365,11 @@ impl PySession {
             snap.files_directory = session.files_directory().to_string_lossy().to_string();
             snap.action_status = session.action_status();
         }
+        let cancel_handle = session.cancel_handle();
         Ok(PySession {
             session: Arc::new(Mutex::new(Some(session))),
             snapshot,
+            cancel_handle,
         })
     }
 
@@ -643,19 +650,36 @@ impl PySession {
         time_limit: Option<f64>,
         mark_action_failed: Option<bool>,
     ) -> PyResult<()> {
-        // cancel_action can be called while an action is running (session is taken).
-        // The Rust Session supports this via CancellationToken which is checked by the
-        // subprocess runner. But we don't have access to &mut Session here.
-        // For now, this is a limitation — cancel requires the session to not be taken.
         let duration = time_limit.map(std::time::Duration::from_secs_f64);
+        let mark_failed = mark_action_failed.unwrap_or(false);
+        // Direct path when the session is not taken (e.g. between actions):
+        // Session::cancel_action also performs the Running -> Canceling state
+        // transition, which the handle cannot (it doesn't own the Session).
         let mut guard = lock_recover(&self.session);
-        match guard.as_mut() {
-            Some(session) => session
-                .cancel_action(duration, mark_action_failed.unwrap_or(false))
-                .map_err(session_err_to_py),
-            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
-                "Cannot cancel: session is busy with an action",
-            )),
+        if let Some(session) = guard.as_mut() {
+            let result = session
+                .cancel_action(duration, mark_failed)
+                .map_err(session_err_to_py);
+            Self::update_snapshot(session, &self.snapshot);
+            return result;
+        }
+        drop(guard);
+
+        // Session is owned by a background action thread: deliver through the
+        // thread-safe cancel handle. Cancellation follows the action's own
+        // cancelation method (including cross-user helper delivery), exactly
+        // like Session::cancel_action.
+        if self.cancel_handle.cancel(duration, mark_failed) {
+            // The handle cannot set the session's transient Canceling state;
+            // reflect it in the snapshot so Python-side pollers observe the
+            // cancel-in-progress phase until the terminal state lands.
+            let mut snap = lock_recover(&self.snapshot);
+            snap.state = SessionState::Canceling;
+            Ok(())
+        } else {
+            Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "Cannot cancel: no action is running",
+            ))
         }
     }
 


### PR DESCRIPTION
> **Reworked 2026-07-24.** The original PR pre-armed a parent `CancellationToken` and cancel-request channel via `set_cancel_parent_token` / `set_cancel_request_channel` — API proposed in openjd-rs#258's original form, which was superseded by `Session::cancel_handle()` (openjd-rs#260, released in openjd-sessions 0.4.0; #258 was distilled to the `terminate_delay` capping and merged separately). This rework replaces the fallback machinery with the handle: smaller diff, same fix.

## What was the problem?

`Session.cancel_action()` failed with "session is busy" whenever an action was actually running: the Rust `Session::cancel_action` needs `&mut Session`, but a background action thread owns the `Session` for exactly that window — the primary window in which callers want to cancel. Mid-action cancels (service-initiated cancels and `time_limit` expiries in Deadline Cloud's worker agent) never reached the job process.

## What is the fix?

Obtain a `SessionCancelHandle` at session construction and route the taken-session case through `handle.cancel(time_limit, mark_action_failed)`. The handle delivers the cancel to the in-flight action without touching the `Session`, following the action's declared cancelation method on both the direct and cross-user helper paths (openjd-sessions 0.4.0 also carries the `min(time_limit, terminate_delay)` grace capping from openjd-rs#258).

One semantic note: the handle cannot perform the `Running → Canceling` session-state transition (it does not own the `Session`), so the binding updates its state snapshot to `Canceling` directly — Python-side pollers keep observing the cancel-in-progress phase until the terminal state lands, preserving the contract that openjd-sessions-for-python#331 (merged) relies on.

## How was this change tested?

* `cargo check` / `clippy --all-targets` / `fmt` clean; `cargo test` (build/link gate) passes against the published crates.io `openjd-sessions 0.4.0` — no patch overrides.
* Full Python suite: 5443 passed; the 4 failures in `test/openjd/expr/test_operation_limit.py` reproduce identically on pristine `mainline` in the same environment (pre-existing, unrelated).
* End-to-end validation with the Deadline Cloud worker agent's differential Python-vs-Rust cancel test suite is the next step and will be reported on this PR.
