### PR TITLE
fix: do not cap <IntRangeExpr> expansion at the list-form limit

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -980,9 +980,14 @@ def validate_let_field(value: Any, info: ValidationInfo, *, simple_action: bool 
     return value
 
 
-# §3.4: the maximum number of values a task parameter's range may take on.
-# Not raised by FEATURE_BUNDLE_1 in 2023-09 (matches openjd-rs's
-# EffectiveLimits.max_task_param_range_len).
+# §3.4: the maximum number of elements in a task parameter's *list*-form range
+# — `<IntRangeList>` (§3.4.1.1), `<FloatRangeList>` (§3.4.1.2) and
+# `<StringRangeList>` (§3.4.1.3). Not raised by FEATURE_BUNDLE_1 in 2023-09.
+#
+# Do not apply this to an `<IntRangeExpr>` expansion. §3.4.1.1.1 constrains that
+# form only by "no two ranges may overlap" and states its purpose is to express
+# frame ranges succinctly, so capping the expansion rejects the form's primary
+# use case and pre-empts the host service's own task-count limits.
 _MAX_TASK_PARAM_RANGE_LEN = 1024
 
 
@@ -1289,26 +1294,6 @@ class RangeExpressionTaskParameterDefinition(OpenJDModel_v2023_09):
     # has a value when type is CHUNK[INT], which is only possible from the TASK_CHUNKING extension
     chunks: Optional[TaskChunksDefinition] = None
 
-    @field_validator("range")
-    @classmethod
-    def _validate_range_len(cls, value: Any) -> Any:
-        # §3.4: a range expression that arrives via format-string resolution
-        # (e.g. `range: "{{RawParam.Frames}}"` with a RANGE_EXPR parameter) is
-        # only parsed at instantiation, so the expansion cap must be enforced
-        # here too — matching openjd-rs's resolve-time checks in create_job.
-        if isinstance(value, IntRangeExpr):
-            _check_range_expr_len(value)
-        return value
-
-
-def _check_range_expr_len(parsed_range: IntRangeExpr) -> None:
-    """§3.4: a range expression may expand to at most 1024 values."""
-    if len(parsed_range) > _MAX_TASK_PARAM_RANGE_LEN:
-        raise ValueError(
-            f"range expression expands to {len(parsed_range)} elements "
-            f"(max {_MAX_TASK_PARAM_RANGE_LEN})."
-        )
-
 
 def _range_task_param_target(model: Any, typed_values: dict) -> Type[OpenJDModel]:
     """``create_as`` target-model selector shared by the INT and CHUNK[INT]
@@ -1412,9 +1397,9 @@ def _native_element_type_name(elem: Any) -> str:
 def _validate_int_range_elements(value: Any) -> Any:
     """Shared ``range`` post-validator for the INT and CHUNK[INT]
     task-parameter definitions: a literal range-expression string must parse
-    and may expand to at most 1024 values (§3.4); a list-form range is
-    length-capped. Ranges containing format expressions defer to the
-    RangeExpressionTaskParameterDefinition model once they are resolved.
+    against the ``<IntRangeExpr>`` grammar; a list-form range is length-capped
+    (§3.4). The expansion of a range expression is deliberately not capped —
+    see ``_MAX_TASK_PARAM_RANGE_LEN``.
     """
     if isinstance(value, FormatString):
         # If there are no format expressions, we can validate the range expression.
@@ -1422,11 +1407,9 @@ def _validate_int_range_elements(value: Any) -> Any:
         # they've all been evaluated
         if len(value.expressions) == 0:
             try:
-                parsed_range = IntRangeExpr.from_str(value)
+                IntRangeExpr.from_str(value)
             except Exception as e:
                 raise ValueError(str(e))
-            # §3.4: the range may take on at most 1024 values.
-            _check_range_expr_len(parsed_range)
     else:
         validate_task_param_range_list_len(value)
     return value

--- a/test/openjd/model_v0/v2023_09/test_parameter_space.py
+++ b/test/openjd/model_v0/v2023_09/test_parameter_space.py
@@ -10,6 +10,8 @@ from openjd.model.v2023_09 import (
     FloatTaskParameterDefinition,
     IntTaskParameterDefinition,
     PathTaskParameterDefinition,
+    RangeExpressionTaskParameterDefinition,
+    RangeListTaskParameterDefinition,
     StepParameterSpaceDefinition,
     StringTaskParameterDefinition,
 )
@@ -329,6 +331,10 @@ class TestRangeExpressionTaskParameterDefinition:
                 },
                 id="format string with multiple",
             ),
+            pytest.param(
+                {"name": "foo", "type": "INT", "range": "1-5000"},
+                id="expansion past the list-form cap",
+            ),
         ),
     )
     def test_parse_success(self, data: dict[str, str]) -> None:
@@ -372,6 +378,64 @@ class TestRangeExpressionTaskParameterDefinition:
             _parse_model(model=IntTaskParameterDefinition, obj=data)
 
         # THEN
+        assert len(excinfo.value.errors()) > 0
+
+
+class TestTaskParameterRangeLength:
+    """§3.4 caps the number of elements in the *list* forms of a task parameter's
+    range. §3.4.1.1.1 `<IntRangeExpr>` carries no element cap, so an expression's
+    expansion must not be capped — the form exists to express frame ranges, which
+    routinely run to thousands of values.
+    """
+
+    @pytest.mark.parametrize(
+        "range_expr,expected_len",
+        (
+            pytest.param("1-1024", 1024, id="at the list-form cap"),
+            pytest.param("1-1025", 1025, id="one past the list-form cap"),
+            pytest.param("1-5000", 5000, id="ordinary frame range"),
+            pytest.param("1-100000:2", 50000, id="large range with a step"),
+        ),
+    )
+    def test_range_expression_expansion_is_not_capped(
+        self, range_expr: str, expected_len: int
+    ) -> None:
+        # WHEN the template-layer definition parses a literal range expression
+        _parse_model(
+            model=IntTaskParameterDefinition,
+            obj={"name": "foo", "type": "INT", "range": range_expr},
+        )
+
+        # AND the instantiation target parses the same expression
+        instantiated = _parse_model(
+            model=RangeExpressionTaskParameterDefinition,
+            obj={"type": "INT", "range": range_expr},
+        )
+
+        # THEN neither rejects it, and the range expands in full
+        assert len(instantiated.range) == expected_len
+
+    @pytest.mark.parametrize(
+        "model,obj",
+        (
+            pytest.param(
+                IntTaskParameterDefinition,
+                {"name": "foo", "type": "INT", "range": [1] * 1025},
+                id="template layer",
+            ),
+            pytest.param(
+                RangeListTaskParameterDefinition,
+                {"type": "INT", "range": [1] * 1025},
+                id="instantiation layer",
+            ),
+        ),
+    )
+    def test_list_form_range_is_still_capped(self, model: Any, obj: dict[str, Any]) -> None:
+        # WHEN a list-form range one element past the §3.4 cap is parsed
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=model, obj=obj)
+
+        # THEN it is rejected
         assert len(excinfo.value.errors()) > 0
 
 


### PR DESCRIPTION
### Problem

`0.11.1` began enforcing a 1024-element cap on the *expansion* of an
`<IntRangeExpr>` task parameter range. §3.4 does not specify that cap for that
form.

The 1024 element limit is stated for the **list** forms only:

- §3.4.1.1 item 4 — `<IntRangeList>`: "Maximum number of elements: The list must not contain more than 1024 elements."
- §3.4.1.2 item 4 — `<FloatRangeList>`: same
- §3.4.1.3 — `<StringRangeList>`: same

§3.4.1.1.1 `<IntRangeExpr>` gives the grammar and exactly one constraint —
"no two ranges in the expression are allowed to overlap" — and no element count.
It also states the form's purpose outright: "The motivating use-case for this
form is providing a succinct way to describe a frame range." Capping the
expansion at 1024 rejects that use case; `range: "1-5000"` is ordinary
submission traffic for a render farm.

The spec is also explicit elsewhere when it wants to grant implementations
latitude to constrain a count — e.g. for step dependencies: "There is no maximum
defined, though implementations may choose to constrain the number of
dependencies." No such allowance is given for `<IntRangeExpr>`, and none is
needed: a host service that wants to bound task counts can do so itself, and
`CallerLimits::max_task_count` exists for exactly that.

Concretely, this is what regressed:

| range elements | 0.11.0 | 0.11.1 | 0.11.2 | this PR |
|---|---|---|---|---|
| 1024 | accept | accept | accept | accept |
| 1025 | accept | reject | reject | accept |
| 10000 | accept | reject | reject | accept |

```
DecodeValidationError: 1 validation errors for JobTemplate
steps[0] -> parameterSpace -> taskParameterDefinitions[0] -> INT -> range:
	range expression expands to 10001 elements (max 1024).
```

Downstream, this pre-empts a host service's own task-count limits. AWS Deadline
Cloud resolves `max-tasks-per-step` per customer account and can raise it; that
mechanism becomes unreachable above 1024 for a single-parameter range, because
decode now fails before the service's own check runs.

### Change

Narrow the cap to the list forms, matching §3.4 as written.

- Delete `_check_range_expr_len` and its two call sites: the
  `RangeExpressionTaskParameterDefinition._validate_range_len` validator (whose
  only job was that check) and the expansion check in
  `_validate_int_range_elements`.
- Keep the `<IntRangeExpr>` **grammar** validation in
  `_validate_int_range_elements` — a malformed expression is still rejected.
- Keep `_MAX_TASK_PARAM_RANGE_LEN` and `validate_task_param_range_list_len`
  unchanged; the list-form cap is correct and predates 0.11.1 (it was already
  enforced in 0.11.0 as `Field(max_length=1024)` on `IntRangeList` /
  `FloatRangeList` / `StringRangeList`).
- Rewrite the constant's comment to record which forms it governs and why the
  expression form is excluded, so the cap does not get re-broadened.

The Rust side carries the same over-broad cap (`max_task_param_range_len`
applied to `IntRange::Expression` in `validate_v2023_09/structure.rs` and to the
`RangeExpr` branches of `job/create_job/ranges.rs`). That lives in the
`openjd-model` crate this repo consumes from crates.io, so it is fixed
separately; this PR is the pure-Python `v0` / `v2023_09` half.

### Testing

The expression cap had no test coverage, so nothing needed deleting. Added
`TestTaskParameterRangeLength` pinning the §3.4 boundary from both directions:

- range expressions at 1024, 1025, 5000 and `1-100000:2` (50000 elements) parse
  at the template layer *and* the instantiation layer, and the range expands in
  full (asserts `len(instantiated.range) == expected_len`, so a future silent
  truncation fails the test);
- list-form ranges of 1025 are still rejected at both layers.

Also added a `1-5000` case to `TestRangeExpressionTaskParameterDefinition`.

Full suite: `5471 passed, 24 skipped, 3 xfailed`.
