### PR TITLE
fix: bump openjd-rs crate deps to 0.4.0/0.5.2/0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openjd-expr"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755fa618da30141da46db5b9a92ca01a645726979ef1f80ee0c6089c66d11793"
+checksum = "38a752942242b0ab0e5106be3bc77b75d5fe55a7fc6785d1d8619fcbd479cc8d"
 dependencies = [
  "regex",
  "regex-syntax",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-model"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503daef7c3f611d5dab0401b989bcca34bf93c6ca4e92b822f642072673a4edd"
+checksum = "b6bc690053425f7975000b85fc94e638c1c25073fd8651cf5f4b08e15f18dc5b"
 dependencies = [
  "indexmap",
  "openjd-expr",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-sessions"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4ea270aaecf3bcd98c28c2d7222b9c75d15f95e26e00f25f18fdfdff9155fa"
+checksum = "4889748a80bb727c242d3d03e2a60baef9a71fd5e548efe213c7dc581e026742"
 dependencies = [
  "bitflags",
  "futures-util",

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -2534,9 +2534,9 @@ limitations under the License.
 ** itoa; version 1.0.18 -- https://crates.io/crates/itoa
 ** libc; version 0.2.189 -- https://crates.io/crates/libc
 ** manyhow-macros; version 0.11.4 -- https://crates.io/crates/manyhow-macros
-** openjd-expr; version 0.3.0 -- https://crates.io/crates/openjd-expr
-** openjd-model; version 0.5.1 -- https://crates.io/crates/openjd-model
-** openjd-sessions; version 0.5.1 -- https://crates.io/crates/openjd-sessions
+** openjd-expr; version 0.4.0 -- https://crates.io/crates/openjd-expr
+** openjd-model; version 0.5.2 -- https://crates.io/crates/openjd-model
+** openjd-sessions; version 0.5.2 -- https://crates.io/crates/openjd-sessions
 ** pin-project-lite; version 0.2.17 -- https://crates.io/crates/pin-project-lite
 ** portable-atomic; version 1.15.0 -- https://crates.io/crates/portable-atomic
 ** proc-macro2; version 1.0.107 -- https://crates.io/crates/proc-macro2

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -12,9 +12,9 @@ name = "_openjd_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-openjd-expr = "0.3.0"
-openjd-model = "0.5.0"
-openjd-sessions = "0.5.0"
+openjd-expr = "0.4.0"
+openjd-model = "0.5.2"
+openjd-sessions = "0.5.2"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"


### PR DESCRIPTION
Picks up the crates published by [openjd-rs#332](https://github.com/OpenJobDescription/openjd-rs/pull/332).

| crate | before | after |
|---|---|---|
| `openjd-expr` | 0.3.0 | 0.4.0 |
| `openjd-model` | 0.5.0 (resolved 0.5.1) | 0.5.2 |
| `openjd-sessions` | 0.5.0 (resolved 0.5.1) | 0.5.2 |

No binding source changes were needed — `openjd-expr` 0.4.0's coercion split
([openjd-rs#329](https://github.com/OpenJobDescription/openjd-rs/pull/329)) does not touch any
API `rust-bindings/` calls, so this is a pin bump, `Cargo.lock`, and the regenerated
`THIRD-PARTY-LICENSES.txt`.

### Behaviour change worth a reviewer's attention

`openjd-model` [#334](https://github.com/OpenJobDescription/openjd-rs/pull/334) reaches Python
through `deserialize_step`, which the worker uses to rebuild a step:

- `"let"` is now accepted as the wire key (previously only `"letBindings"` was, so `"let"` was
  silently dropped and expressions referencing those bindings failed with "Undefined variable").
- `StepScript`/`EnvironmentScript` gained `deny_unknown_fields`, so an unrecognised script key
  now raises instead of being ignored:
  `ValueError: failed to deserialize Step: unknown field 'bogus', expected one of 'let', 'letBindings', 'actions', 'embeddedFiles'`

Both verified against the rebuilt extension. The tightening is the only outward-facing
regression risk here; upstream shipped it as a patch release, hence `fix:` rather than `feat!:`.

Also in the pickup: list-parameter element coercion
([#335](https://github.com/OpenJobDescription/openjd-rs/pull/335)), symbol-table parameter
coercion ([#330](https://github.com/OpenJobDescription/openjd-rs/pull/330)), list-to-string
element escaping ([#336](https://github.com/OpenJobDescription/openjd-rs/pull/336)), and seven
overflow/panic/silent-wrong-value fixes ([#321](https://github.com/OpenJobDescription/openjd-rs/pull/321)).

### Testing

| check | result |
|---|---|
| `cargo build --manifest-path rust-bindings/Cargo.toml --all-targets` | pass |
| `cargo clippy --manifest-path rust-bindings/Cargo.toml --all-targets -- -D warnings` | pass |
| `cargo test --manifest-path rust-bindings/Cargo.toml` (+ `--doc`) | pass (no tests in crate) |
| `hatch run test` against a rebuilt extension | 5479 passed, 24 skipped, 3 xfailed |
| `scripts/check_third_party_licenses.sh` | up to date |

No xfail in `test_known_gaps.py` xpassed, so nothing needed re-homing.

Local `hatch run test` reports 93.98% against the 94% gate. That number is identical before and
after the bump (same missed lines with the 0.5.1 and 0.5.2 extensions) and comes from 24 tests
skipped in my environment, not from this change.
