### PR TITLE
ci: Add cargo to dependabot so openjd-rs releases open their own PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "cargo"
+    directory: "/" # Workspace root; rust-bindings is discovered as a member
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    # Patch bumps are combined into a single PR. Minor bumps do not match this
+    # group and so each get their own individual PR, because every crate this
+    # package depends on is pre-1.0: for a 0.x crate cargo treats a minor bump
+    # as breaking, so openjd-expr 0.3 -> 0.4 deserves its own review rather
+    # than riding along with a patch.
+    groups:
+      cargo-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Dependabot watches `pip` and `github-actions` but not `cargo`, so a new `openjd-expr` /
`openjd-model` / `openjd-sessions` release is only noticed when somebody goes looking.
[#335](https://github.com/OpenJobDescription/openjd-model-for-python/pull/335) is the worked
example: the crates published, and picking them up was a manual chase for pins, `Cargo.lock`, and
`THIRD-PARTY-LICENSES.txt`. This makes that arrive as a PR on its own.

### Loosening the version requirements would not have helped

Worth stating because it is the obvious alternative. The requirements are already permissive
enough — `openjd-model = "0.5.2"` is `^0.5.2`, so `>=0.5.2, <0.6.0`, and a 0.5.3 satisfies it
without an edit. `Cargo.lock` is what actually pins the build, and it is committed and is what CI
resolves from. So a patch pickup needs a `cargo update` and a commit no matter how loose the
requirement string is, and a `*` requirement would buy nothing while giving up the reproducibility
the lock exists for.

### Why patch-only grouping, unlike the pip entry

| Bump | Lands as |
|---|---|
| `openjd-model` 0.5.2 -> 0.5.3 | grouped, one PR with any other patch bumps |
| `openjd-expr` 0.3.0 -> 0.4.0 | its own PR |

Every crate here is pre-1.0, and cargo treats a minor bump of a 0.x crate as breaking. That is not
theoretical: `openjd-expr` 0.4.0 carried a `[**breaking**]` coercion change, and `openjd-model`
0.5.2 changed the job-side `StepScript` wire format. Those deserve their own CI run and their own
review rather than riding along with a patch. The `pip` entry groups minor and patch together
because its dependencies are 1.0+, where minor is additive.

### The one manual step this leaves

`scripts/check_third_party_licenses.sh` fails on a `Cargo.lock` change alone, so that check will be
red on every cargo PR until the file is regenerated [measured — a lock-only diff of the three
openjd versions failed the check]. The follow-up is one command pushed to the dependabot branch:

```bash
scripts/check_third_party_licenses.sh --update
```

**(Alternate, if you would rather it be zero-touch)** a scheduled workflow that runs
`cargo update -p openjd-expr -p openjd-model -p openjd-sessions`, regenerates the license file, and
opens the PR itself. That removes the manual step and scopes updates to the three crates that
matter, at the cost of ~40 lines of workflow YAML and a token with PR-write permission. I went with
dependabot because it matches what this repo already does; happy to switch if you prefer the
workflow.

### Testing

Config parses as YAML and declares all three ecosystems; the `cargo` entry's `directory: "/"` is
where `Cargo.toml` and `Cargo.lock` actually live, with `rust-bindings` picked up as a workspace
member. I cannot run dependabot itself, so the schedule and grouping behaviour are unverified
until it runs on Monday.
