### PR TITLE
Allow an environment to define only onExit

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -758,15 +758,6 @@ class EnvironmentActions(OpenJDModel_v2023_09):
 
         on_enter = values.get("onEnter")
         on_exit = values.get("onExit")
-        # Base 2023-09 (§3.5) requires onEnter whenever a script is present;
-        # RFC 0008 relaxes this to "at least one action" when the
-        # WRAP_ACTIONS extension is declared. The strict base rule is only
-        # applied at template decode (context present) — job-instantiation
-        # re-validation has no parsing context, matching the other extension
-        # gates in this module.
-        if context is not None and "WRAP_ACTIONS" not in extensions:
-            if on_enter is None:
-                raise ValueError("onEnter is required.")
         if on_enter is None and on_exit is None:
             raise ValueError("Must define one of: onEnter or onExit")
         return values

--- a/test/openjd/model_v0/v2023_09/test_action.py
+++ b/test/openjd/model_v0/v2023_09/test_action.py
@@ -164,6 +164,7 @@ class TestEnvironmentActions:
         "data",
         (
             pytest.param({"onEnter": {"command": "foo"}}, id="has onEnter"),
+            pytest.param({"onExit": {"command": "foo"}}, id="has onExit"),
             # For making sure our pre-validator logic is correct
             pytest.param(
                 {
@@ -187,26 +188,35 @@ class TestEnvironmentActions:
         # THEN
         # no exception was raised.
 
-    def test_parse_onexit_only_with_wrap_actions_extension(self) -> None:
-        # RFC 0008: with the WRAP_ACTIONS extension declared, an environment
-        # may define any single action without a standalone onEnter.
+    @pytest.mark.parametrize(
+        "supported_extensions",
+        (
+            pytest.param([], id="no extensions"),
+            pytest.param(["EXPR", "WRAP_ACTIONS"], id="EXPR and WRAP_ACTIONS"),
+        ),
+    )
+    def test_parse_onexit_only(self, supported_extensions: list[str]) -> None:
+        # An environment may define onExit without onEnter; either ordinary
+        # action alone satisfies the one-of requirement, with or without an
+        # extension being declared.
 
         # GIVEN
-        context = ModelParsingContext(supported_extensions=["EXPR", "WRAP_ACTIONS"])
+        context = ModelParsingContext(supported_extensions=supported_extensions)
 
         # WHEN
-        _parse_model(model=EnvironmentActions, obj={"onExit": {"command": "foo"}}, context=context)
+        actions = _parse_model(
+            model=EnvironmentActions, obj={"onExit": {"command": "foo"}}, context=context
+        )
 
         # THEN
-        # no exception was raised.
+        assert actions.onEnter is None
+        assert actions.onExit is not None
+        assert actions.onExit.command == "foo"
 
     @pytest.mark.parametrize(
         "data",
         (
             pytest.param({}, id="empty object"),
-            # §3.5: base 2023-09 requires onEnter whenever a script is
-            # present (the WRAP_ACTIONS extension relaxes this).
-            pytest.param({"onExit": {"command": "foo"}}, id="onExit only"),
             pytest.param({"onEnter": {"command": "foo"}, "onUnknown": "blah"}, id="unknown field"),
         ),
     )
@@ -219,3 +229,15 @@ class TestEnvironmentActions:
 
         # THEN
         assert len(excinfo.value.errors()) > 0
+
+    def test_parse_fails_no_actions_message(self) -> None:
+        # An actions object with neither ordinary action must be rejected with
+        # the one-of message; this is the only remaining constraint on which
+        # ordinary actions an environment defines.
+
+        # WHEN
+        with pytest.raises(ValidationError) as excinfo:
+            _parse_model(model=EnvironmentActions, obj={})
+
+        # THEN
+        assert "Must define one of: onEnter or onExit" in str(excinfo.value)

--- a/test/openjd/model_v0/v2023_09/test_environment_template.py
+++ b/test/openjd/model_v0/v2023_09/test_environment_template.py
@@ -24,6 +24,16 @@ class TestEnvironmentTemplate:
             pytest.param(
                 {
                     "specificationVersion": "environment-2023-09",
+                    "environment": {
+                        "name": "Foo",
+                        "script": {"actions": {"onExit": {"command": "foo"}}},
+                    },
+                },
+                id="script with onExit only",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "environment-2023-09",
                     "parameterDefinitions": [{"name": "P", "type": "INT"}],
                     "environment": ENVIRONMENT,
                 },

--- a/test/openjd/model_v0/v2023_09/test_job_template.py
+++ b/test/openjd/model_v0/v2023_09/test_job_template.py
@@ -79,6 +79,20 @@ class TestJobTemplate:
                     "name": "Foo",
                     "steps": [STEP_TEMPLATE],
                     "jobEnvironments": [
+                        {
+                            "name": "Foo",
+                            "script": {"actions": {"onExit": {"command": "foo"}}},
+                        }
+                    ],
+                },
+                id="with environment defining onExit only",
+            ),
+            pytest.param(
+                {
+                    "specificationVersion": "jobtemplate-2023-09",
+                    "name": "Foo",
+                    "steps": [STEP_TEMPLATE],
+                    "jobEnvironments": [
                         {"name": f"E{i}", "script": ENV_SCRIPT} for i in range(0, 10)
                     ],
                 },


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

An environment script that defines `onExit` without `onEnter` is rejected at template decode:

```
environment -> script -> actions:
	onEnter is required.
```

This blocks cleanup-only environments. The motivating case is a queue environment whose only work is tearing down state established elsewhere in the session, but the same environment type is used by `jobEnvironments` and step environments, so all three are affected.

The rejection comes from a check added in #318 as a validation tightening. Before that change this validator only required that *one* of the two ordinary actions be present:

```python
if on_enter is None and on_exit is None:
    raise ValueError("Must define one of: onEnter or onExit")
```

### What was the solution? (How)

Remove the added `onEnter is required.` branch and restore the one-of rule. An ordinary environment script must define `onEnter` or `onExit`; either action alone is sufficient.

Unchanged:

- an `actions` object defining neither ordinary action is still rejected with `Must define one of: onEnter or onExit`
- `WRAP_ACTIONS` extension gating, the `EXPR` prerequisite, and the all-or-nothing wrap-hook rule
- the wrapped-variable scope rules

The removed check was also the only reason the ordinary-action path inspected the parsing context, so validation no longer differs between template decode and job instantiation.

### What is the impact of this change?

Templates that were previously rejected are now accepted. Nothing that was accepted becomes rejected.

| Environment `actions` | Before | After |
|---|---|---|
| `onEnter` only | accepted | accepted |
| `onEnter` and `onExit` | accepted | accepted |
| `onExit` only | **rejected** | **accepted** |
| neither | rejected | rejected |
| complete wrap-hook set | accepted | accepted |
| partial or ungated wrap hooks | rejected | rejected |

**Cross-implementation note:** `openjd-rs` still rejects `onExit`-only, so this change makes the two implementations disagree until the same change lands there. The corresponding conformance case is proposed in openjd-specifications.

### How was this change tested?

- `hatch run test` — 5483 passed, 24 skipped, 3 xfailed, coverage 94%
- `hatch run lint` — ruff, black, and mypy clean
- `hatch build` — sdist and wheel built
- Full 2023-09 conformance suite against the rebuilt wheel — 1160 passed, 2 failed. Both failures are the existing `onExit`-only fixtures that assert rejection and are updated in the companion openjd-specifications change.
- The new unit tests were mutation-checked: restoring the removed branch makes them fail.

New tests:

- `test_action.py` — `onExit`-only accepted both with no extensions and with `EXPR`/`WRAP_ACTIONS`, asserting the decoded actions; empty `actions` still rejected, asserted on the full error message
- `test_environment_template.py` — a standalone `environment-2023-09` template whose script defines only `onExit`
- `test_job_template.py` — a `jobEnvironments` entry whose script defines only `onExit`

- Have you run the unit tests? Yes.

### Was this change documented?

- Are relevant docstrings in the code base updated? The validator docstring already described the one-of rule, which is accurate again. The class docstring already stated "Must define at least one of onEnter or onExit".

### Is this a breaking change?

No. The change only widens what is accepted.

### Does this change impact security?

No. No files, directories, permissions, or process boundaries are affected.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
