### PR TITLE
chore: pin GitPython for release bump

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,2 @@
 python-semantic-release == 10.6.*
+GitPython == 3.1.59


### PR DESCRIPTION
https://github.com/python-semantic-release/python-semantic-release/pull/1477 - GitPython break semantic, pin to an older version pending fixes from upstream