### PR TITLE
fix: Keep the trailing zeros of a floatstring range element

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1258,74 +1258,29 @@ class TaskChunksDefinition(OpenJDModel_v2023_09):
         return validate_int_fmtstring_field(value, ge=0, context=context)
 
 
+# '02.50' -> '2.50', '007' -> '7', '000' -> '0'. The lookahead leaves the last
+# digit, so '0.50' keeps the zero that is its integer part.
+_REDUNDANT_LEADING_ZEROS = re.compile(r"^([+-]?)0+(?=[0-9])")
+
+
 def _normalized_range_element(elem: str, to_int: bool) -> Any:
-    """The number an ``<intstring>``/``<floatstring>`` range element denotes -- an
-    ``int`` for ``<intstring>``, and for ``<floatstring>`` the plain-notation text
-    of the value, since ``str(Decimal)`` cannot render every magnitude without an
-    exponent. Returns the element unchanged when it does not denote a number, or
-    when its plain-notation form would not fit this field's character cap."""
+    """The value an ``<intstring>``/``<floatstring>`` range element denotes.
+
+    An ``<intstring>`` becomes an ``int``. A ``<floatstring>`` keeps its text less
+    redundant leading zeros, so the decimal places it was written with survive
+    (§7.5). Returns the element unchanged when it does not denote a number.
+    """
     try:
         if to_int:
-            return int(elem)
-        value = Decimal(elem)
-        if not value.is_finite():
-            # Decimal accepts 'nan'/'inf', which are not <floatstring>s; leave
-            # them as text rather than changing how they render.
-            return elem
-        # Bound the expansion from the exponent before performing it. Decimal
-        # construction from a string is unbounded -- the context's Emax/Emin
-        # constrain arithmetic results, not construction, so Decimal('1e999999999')
-        # is finite and the guard above does not stop it -- and the plain-notation
-        # length is linear in the exponent, so 11 characters of template text
-        # would otherwise materialize ~10**9 characters.
-        #
-        # The bound is the character cap this field already enforces, because an
-        # expansion past it cannot be carried here as text at all: the value is
-        # stored in a TaskRangeList element, whose str member is
-        # TaskParameterStringValueAsJob, and pydantic's union falls through to
-        # the numeric members instead, rendering the element as an integer, or as
-        # inf, or as 0.0. Such an element keeps its source text -- what this
-        # function already does for anything it cannot normalize, and how it
-        # rendered before normalization was introduced.
-        exponent = cast(int, value.as_tuple().exponent)  # finite: never 'n'/'N'/'F'
-        # Length of the '[-]<integer>.<fraction>' text returned below. Stripping
-        # redundant zeros can only shorten it, so this is an upper bound.
-        expansion_len = (
-            (1 if value.is_signed() else 0)
-            + max(value.adjusted() + 1, 1)  # integer digits, at least one
-            + 1  # the decimal point
-            + max(-exponent, 1)  # fraction digits, at least one
-        )
-        if expansion_len > _MAX_TASK_PARAM_VALUE_LEN:
-            return elem
-        # format(value, 'f') is exact and plain at every magnitude: with no
-        # precision in the format spec it neither rounds to getcontext().prec
-        # nor switches to exponent notation, so an embedding app that sets a
-        # different context cannot change what this library renders. Neither
-        # holds of the obvious alternatives -- normalize() rounds to the
-        # ambient precision, str() switches to exponent notation below 1e-6,
-        # and quantize() raises InvalidOperation once the result needs more
-        # digits than the ambient precision allows.
-        text = format(value, "f")
-        negative = text.startswith("-")
-        integer, _, fraction = text.lstrip("-").partition(".")
-        # A <floatstring> denotes a number, so redundant zeros in its source
-        # text are not part of the value: '02.50' is 2.5. One fractional digit
-        # is always kept, matching openjd-rs, which renders the float 1.0 as
-        # `1.0` and never as `1`.
-        integer = integer.lstrip("0") or "0"
-        fraction = fraction.rstrip("0") or "0"
-        if negative and integer == "0" and fraction == "0":
-            # The number denoted by '-0.0' is zero, which has no sign; openjd-rs
-            # renders it `0.0`.
-            negative = False
-        return f"{'-' if negative else ''}{integer}.{fraction}"
-    except (ValueError, ArithmeticError):
-        # Not a number at all — e.g. a format string that resolved to
-        # non-numeric text. A literal range is already checked against its
-        # element type at template parse time, so leave such a value to the
-        # existing behaviour rather than adding a rejection path here.
+            return int(elem)  # int() already drops leading zeros
+        # Parsed only to check it is a number; the text is what renders. Not a
+        # Decimal -- re-rendering one is context-sensitive and unbounded (§7.5).
+        float(elem)
+    except ValueError:
+        # A resolved format string can be non-numeric. Literals are checked at
+        # template parse time, so carry it through rather than rejecting here.
         return elem
+    return _REDUNDANT_LEADING_ZEROS.sub(r"\1", elem)
 
 
 # Target model for task parameters when instantiating a job.
@@ -1340,22 +1295,14 @@ class RangeListTaskParameterDefinition(OpenJDModel_v2023_09):
     @field_validator("range", mode="before")
     @classmethod
     def _normalize_numeric_range_elements(cls, value: Any, info: ValidationInfo) -> Any:
-        # §3.4.1.1/§3.4.1.2: an <IntRangeList> element is `<integer> |
-        # <intstring>` and a <FloatRangeList> element is `<float> |
-        # <floatstring>`, where an <intstring>/<floatstring> is "a string whose
-        # value is the string representation of" a number (§2.3, §2.4). Such an
-        # element therefore denotes that number, not its source text, so '02'
-        # is the task value 2 and '02.50' is 2.5. Python was keeping the source
-        # text, which reaches a task command line as `--frame 02`.
+        # §7.5: a string-form range element loses redundant leading zeros and
+        # keeps its decimal places, so '02' is the value 2 and '02.50' renders
+        # `2.50`. Numeric literals carry no such request and are left as parsed;
+        # STRING and PATH ranges have no numeric form at all.
         #
-        # Applied on the instantiation target so every inbound range path is
-        # covered: a literal list, a range-expression expansion, and an RFC 0006
-        # typed whole-field resolution all funnel through this model.
-        #
-        # Numeric elements are left exactly as parsed. A FLOAT range of [1.0]
-        # renders 1.0, which openjd-rs also does and the conformance suite pins
-        # (base/jobs/3.4--float-parameter). STRING and PATH ranges are text by
-        # definition and are never touched.
+        # On the instantiation target so all three inbound paths are covered: a
+        # literal list, a range-expression expansion, and RFC 0006 whole-field
+        # resolution.
         param_type = info.data.get("type")
         if not isinstance(value, list) or param_type not in (
             TaskParameterType.INT,

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1275,12 +1275,21 @@ def _normalized_range_element(elem: str, to_int: bool) -> Any:
             return int(elem)  # int() already drops leading zeros
         # Parsed only to check it is a number; the text is what renders. Not a
         # Decimal -- re-rendering one is context-sensitive and unbounded (§7.5).
-        float(elem)
+        value = float(elem)
     except ValueError:
         # A resolved format string can be non-numeric. Literals are checked at
         # template parse time, so carry it through rather than rejecting here.
         return elem
-    return _REDUNDANT_LEADING_ZEROS.sub(r"\1", elem)
+    # Trimmed because the text reaches a command line and float() ignores
+    # surrounding whitespace; openjd-rs trims here too.
+    text = _REDUNDANT_LEADING_ZEROS.sub(r"\1", elem.strip())
+    if value == 0.0:
+        # Zero has no sign, so drop one without dropping the decimal places:
+        # '-0.00' renders `0.00`. Text that reaches zero only by underflow, like
+        # '1e-400', does not render the value at all and is not kept.
+        unsigned = text.lstrip("+-")
+        return unsigned if set(unsigned) <= {"0", "."} else "0.0"
+    return text
 
 
 # Target model for task parameters when instantiating a job.

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -1262,6 +1262,14 @@ class TaskChunksDefinition(OpenJDModel_v2023_09):
 # digit, so '0.50' keeps the zero that is its integer part.
 _REDUNDANT_LEADING_ZEROS = re.compile(r"^([+-]?)0+(?=[0-9])")
 
+# An all-zero mantissa, whatever the exponent: '0.00', '-0.0' and '0e5' spell zero,
+# '1e-400' does not. Mirrors openjd_expr::value::text_spells_zero.
+_SPELLS_ZERO = re.compile(r"^[+-]?[0.]*[0][0.]*(?:[eE][+-]?[0-9]+)?$")
+
+
+def _spells_zero(text: str) -> bool:
+    return _SPELLS_ZERO.match(text) is not None
+
 
 def _normalized_range_element(elem: str, to_int: bool) -> Any:
     """The value an ``<intstring>``/``<floatstring>`` range element denotes.
@@ -1275,7 +1283,7 @@ def _normalized_range_element(elem: str, to_int: bool) -> Any:
             return int(elem)  # int() already drops leading zeros
         # Parsed only to check it is a number; the text is what renders. Not a
         # Decimal -- re-rendering one is context-sensitive and unbounded (§7.5).
-        value = float(elem)
+        float(elem)
     except ValueError:
         # A resolved format string can be non-numeric. Literals are checked at
         # template parse time, so carry it through rather than rejecting here.
@@ -1283,13 +1291,11 @@ def _normalized_range_element(elem: str, to_int: bool) -> Any:
     # Trimmed because the text reaches a command line and float() ignores
     # surrounding whitespace; openjd-rs trims here too.
     text = _REDUNDANT_LEADING_ZEROS.sub(r"\1", elem.strip())
-    if value == 0.0:
-        # Zero has no sign, so drop one without dropping the decimal places:
-        # '-0.00' renders `0.00`. Text that reaches zero only by underflow, like
-        # '1e-400', does not render the value at all and is not kept.
-        unsigned = text.lstrip("+-")
-        return unsigned if set(unsigned) <= {"0", "."} else "0.0"
-    return text
+    # Zero has no sign, so drop one without dropping the decimal places: '-0.00'
+    # renders `0.00`. Decided from the text, not from `value` -- the parse
+    # underflows to 0.0 below ~5e-324, and a tiny value's digits are exactly what
+    # a <floatstring> is for.
+    return text.lstrip("+-") if _spells_zero(text) else text
 
 
 # Target model for task parameters when instantiating a job.

--- a/test/openjd/model_v0/test_step_param_space_iter.py
+++ b/test/openjd/model_v0/test_step_param_space_iter.py
@@ -613,8 +613,8 @@ class TestRangeListElementValues:
 
     def test_float_range_floatstring_elements(self) -> None:
         # WHEN a FLOAT range is written with <floatstring> elements
-        # THEN each task gets the number the element denotes
-        assert self._task_values("FLOAT", ["1.5", "02.50"]) == ["1.5", "2.5"]
+        # THEN each task gets the element's text, less redundant leading zeros
+        assert self._task_values("FLOAT", ["1.5", "02.50", "3.500"]) == ["1.5", "2.50", "3.500"]
 
     def test_float_range_numeric_literals_keep_their_scale(self) -> None:
         # A <float> literal is not a string representation, so it keeps the scale

--- a/test/openjd/model_v0/v2023_09/test_parameter_space.py
+++ b/test/openjd/model_v0/v2023_09/test_parameter_space.py
@@ -485,6 +485,16 @@ class TestRangeListElementNormalization:
             pytest.param("0", "0", id="bare zero"),
             pytest.param("0.0", "0.0", id="zero"),
             pytest.param("0.00", "0.00", id="zero keeps its trailing zeros too"),
+            # Zero has no sign, which openjd-rs and mainline both render away.
+            # Dropping it must not drop the decimal places with it.
+            pytest.param("-0.0", "0.0", id="negative zero has no sign"),
+            pytest.param("-0.00", "0.00", id="unsigned, but still two places"),
+            # Reaches zero only by underflow, so the text does not render the
+            # value and is not kept.
+            pytest.param("1e-400", "0.0", id="underflow to zero"),
+            # float() ignores surrounding whitespace and this text reaches a
+            # command line, so it is trimmed rather than forwarded.
+            pytest.param("  1.5  ", "1.5", id="surrounding whitespace"),
             pytest.param("1.0", "1.0", id="integral float keeps its point"),
             # Exponent notation is the author's own text and is forwarded. The
             # FLOAT parameter default path does the same for `default: "1E+2"`.
@@ -508,25 +518,33 @@ class TestRangeListElementNormalization:
         assert [str(v) for v in model.range] == [expected]
 
     @pytest.mark.parametrize(
-        "element",
+        "element,expected",
         (
-            pytest.param("1e999999999", id="huge positive exponent"),
-            pytest.param("1e-999999999", id="huge negative exponent"),
-            pytest.param("1E+1022", id="positive exponent past the field cap"),
-            pytest.param("1E-1023", id="negative exponent past the field cap"),
+            # An exponent too large for a float still costs only its own
+            # characters, which is the whole point: nothing expands it.
+            pytest.param("1e999999999", "1e999999999", id="huge positive exponent"),
+            pytest.param("1E+1022", "1E+1022", id="positive exponent past the field cap"),
+            # Too small, and the value underflows to zero, so the text no longer
+            # renders it. openjd-rs resolves these to zero and renders 0.0 too.
+            pytest.param("1e-999999999", "0.0", id="huge negative exponent"),
+            pytest.param("1E-1023", "0.0", id="negative exponent past the field cap"),
         ),
     )
-    def test_a_huge_exponent_costs_only_its_own_characters(self, element: str) -> None:
+    def test_a_huge_exponent_costs_only_its_own_characters(
+        self, element: str, expected: str
+    ) -> None:
         # WHEN 11 characters of template text denote a number needing ~10**9
         # digits in plain notation
         model = _parse_model(
             model=RangeListTaskParameterDefinition, obj={"type": "FLOAT", "range": [element]}
         )
 
-        # THEN it renders as its own text. Nothing expands it, so no exponent
-        # bound is needed and the value cannot exceed the field's 1024-character
-        # cap and fall through to a numeric member of the union.
-        assert [str(v) for v in model.range] == [element]
+        # THEN nothing expands it, so no bound on the exponent is needed to stop a
+        # template allocating ~10**9 characters. Long *literal* text can still
+        # exceed TaskParameterStringValueAsJob's cap and fall through to a numeric
+        # member of the union, as it does on mainline and in 0.11.6; only the
+        # expansion is gone.
+        assert [str(v) for v in model.range] == [expected]
 
     def test_floatstring_rendering_ignores_the_decimal_context(self) -> None:
         # GIVEN an embedding application that has narrowed the process-wide

--- a/test/openjd/model_v0/v2023_09/test_parameter_space.py
+++ b/test/openjd/model_v0/v2023_09/test_parameter_space.py
@@ -489,9 +489,12 @@ class TestRangeListElementNormalization:
             # Dropping it must not drop the decimal places with it.
             pytest.param("-0.0", "0.0", id="negative zero has no sign"),
             pytest.param("-0.00", "0.00", id="unsigned, but still two places"),
-            # Reaches zero only by underflow, so the text does not render the
-            # value and is not kept.
-            pytest.param("1e-400", "0.0", id="underflow to zero"),
+            # An all-zero mantissa spells zero whatever the exponent.
+            pytest.param("0E+2", "0E+2", id="exponent form of zero"),
+            pytest.param("-0e5", "0e5", id="signed exponent form of zero"),
+            # Underflow is not zero being spelled: the digits are the request.
+            pytest.param("1e-400", "1e-400", id="underflow keeps its digits"),
+            pytest.param("0." + "0" * 400 + "1", "0." + "0" * 400 + "1", id="tiny plain decimal"),
             # float() ignores surrounding whitespace and this text reaches a
             # command line, so it is trimmed rather than forwarded.
             pytest.param("  1.5  ", "1.5", id="surrounding whitespace"),
@@ -524,10 +527,10 @@ class TestRangeListElementNormalization:
             # characters, which is the whole point: nothing expands it.
             pytest.param("1e999999999", "1e999999999", id="huge positive exponent"),
             pytest.param("1E+1022", "1E+1022", id="positive exponent past the field cap"),
-            # Too small, and the value underflows to zero, so the text no longer
-            # renders it. openjd-rs resolves these to zero and renders 0.0 too.
-            pytest.param("1e-999999999", "0.0", id="huge negative exponent"),
-            pytest.param("1E-1023", "0.0", id="negative exponent past the field cap"),
+            # Too small for a float either way, and the digits still stand:
+            # underflowing to 0.0 is a parse limit, not the author writing zero.
+            pytest.param("1e-999999999", "1e-999999999", id="huge negative exponent"),
+            pytest.param("1E-1023", "1E-1023", id="negative exponent past the field cap"),
         ),
     )
     def test_a_huge_exponent_costs_only_its_own_characters(

--- a/test/openjd/model_v0/v2023_09/test_parameter_space.py
+++ b/test/openjd/model_v0/v2023_09/test_parameter_space.py
@@ -441,13 +441,12 @@ class TestTaskParameterRangeLength:
 
 
 class TestRangeListElementNormalization:
-    """§3.4.1.1/§3.4.1.2: an `<IntRangeList>` element is `<integer> | <intstring>`
-    and a `<FloatRangeList>` element is `<float> | <floatstring>`. An
-    `<intstring>`/`<floatstring>` is "a string whose value is the string
-    representation of" a number (§2.3, §2.4), so it denotes that number and not
-    its source text — a range of `['1', '02', '003']` is the task values 1, 2 and
-    3. These values reach a task command line, so keeping the text renders
-    `--frame 02`.
+    """§7.5 on a range element: leading zeros go, decimal places stay.
+
+    `['1', '02', '003']` is the task values 1, 2 and 3; keeping the text renders
+    `--frame 02`. But `'2.50'` renders `2.50`, because the string form is how a
+    template asks for a fixed number of decimal places —
+    `EXPR/jobs/expr1.3.4--float-passthrough` pins that for a FLOAT default.
     """
 
     @pytest.mark.parametrize(
@@ -471,96 +470,65 @@ class TestRangeListElementNormalization:
     @pytest.mark.parametrize(
         "element,expected",
         (
-            pytest.param("1.5", "1.5", id="no normalization needed"),
-            pytest.param("02.50", "2.5", id="leading and trailing zeros"),
-            pytest.param("3.500", "3.5", id="trailing zeros"),
-            pytest.param("-02.50", "-2.5", id="negative"),
-            # An integral float keeps one fractional digit. openjd-rs renders
-            # the <floatstring> '1.0' as `1.0` and '007' as `7.0`, so dropping
-            # the fraction would make the same number render two ways depending
-            # on whether it was written as a <float> or a <floatstring>.
-            pytest.param("1.0", "1.0", id="integral float"),
+            pytest.param("1.5", "1.5", id="nothing to strip"),
+            # The rule, in both directions at once.
+            pytest.param("02.50", "2.50", id="leading zero goes, trailing zero stays"),
+            pytest.param("3.500", "3.500", id="trailing zeros stay"),
+            pytest.param("-02.50", "-2.50", id="negative"),
+            pytest.param("+02.50", "+2.50", id="explicit plus sign is kept"),
+            pytest.param("007", "7", id="leading zeros on a whole number"),
+            pytest.param("100", "100", id="a zero that is a significant digit"),
+            # Neither the zero before the point nor the last of an all-zero
+            # integer part is redundant.
+            pytest.param("0.50", "0.50", id="the necessary leading zero stays"),
+            pytest.param("000", "0", id="all zeros keeps one"),
+            pytest.param("0", "0", id="bare zero"),
             pytest.param("0.0", "0.0", id="zero"),
-            pytest.param("-0.0", "0.0", id="negative zero has no sign"),
-            pytest.param("007", "7.0", id="leading zeros on a whole number"),
-            pytest.param("100", "100.0", id="whole number"),
-            # Exponent notation must never reach a task command line, at any
-            # magnitude and in either direction.
-            pytest.param("1E+2", "100.0", id="exponent notation in the source"),
-            pytest.param(
-                "0.0000001",
-                "0.0000001",
-                id="below 1e-6, where Decimal.__str__ would give 1E-7",
-            ),
-            pytest.param(
-                "1E+30",
-                "1" + "0" * 30 + ".0",
-                id="more digits than the default decimal precision",
-            ),
+            pytest.param("0.00", "0.00", id="zero keeps its trailing zeros too"),
+            pytest.param("1.0", "1.0", id="integral float keeps its point"),
+            # Exponent notation is the author's own text and is forwarded. The
+            # FLOAT parameter default path does the same for `default: "1E+2"`.
+            pytest.param("1E+2", "1E+2", id="exponent notation"),
+            pytest.param("01E+2", "1E+2", id="leading zero on an exponent form"),
+            pytest.param("0.0000001", "0.0000001", id="below 1e-6"),
             pytest.param(
                 "1.2345678901234567890123456789012345678901",
                 "1.2345678901234567890123456789012345678901",
-                id="more significant digits than the default decimal precision",
+                id="more significant digits than a float can hold",
             ),
         ),
     )
-    def test_floatstring_elements_carry_their_value(self, element: str, expected: str) -> None:
+    def test_floatstring_elements_keep_their_scale(self, element: str, expected: str) -> None:
         # WHEN the instantiation target parses a float range holding a <floatstring>
         model = _parse_model(
             model=RangeListTaskParameterDefinition, obj={"type": "FLOAT", "range": [element]}
         )
 
-        # THEN the element renders as the number it denotes
+        # THEN it renders as written, less any redundant leading zeros
         assert [str(v) for v in model.range] == [expected]
 
     @pytest.mark.parametrize(
         "element",
         (
-            # Decimal's context bounds arithmetic results, not construction from
-            # a string, so these are finite: 11 characters of template text
-            # whose plain-notation expansion is ~10**9 characters.
             pytest.param("1e999999999", id="huge positive exponent"),
             pytest.param("1e-999999999", id="huge negative exponent"),
-            # One character past the cap in each direction: both expand to 1025.
-            pytest.param("1E+1022", id="one past the cap, positive exponent"),
-            pytest.param("1E-1023", id="one past the cap, negative exponent"),
+            pytest.param("1E+1022", id="positive exponent past the field cap"),
+            pytest.param("1E-1023", id="negative exponent past the field cap"),
         ),
     )
-    def test_element_too_long_to_expand_keeps_its_source_text(self, element: str) -> None:
-        # WHEN the instantiation target parses a <floatstring> whose plain-notation
-        # form would not fit TaskParameterStringValueAsJob's 1024-character cap
+    def test_a_huge_exponent_costs_only_its_own_characters(self, element: str) -> None:
+        # WHEN 11 characters of template text denote a number needing ~10**9
+        # digits in plain notation
         model = _parse_model(
             model=RangeListTaskParameterDefinition, obj={"type": "FLOAT", "range": [element]}
         )
 
-        # THEN it keeps its source text rather than being expanded. Expanding it
-        # would allocate the whole expansion, and the result could not be carried
-        # as text here anyway: it fails the str member of TaskRangeList's union,
-        # and pydantic then falls through to the numeric members, rendering the
-        # element as an integer, or as inf, or as 0.0.
+        # THEN it renders as its own text. Nothing expands it, so no exponent
+        # bound is needed and the value cannot exceed the field's 1024-character
+        # cap and fall through to a numeric member of the union.
         assert [str(v) for v in model.range] == [element]
 
-    @pytest.mark.parametrize(
-        "element,expected",
-        (
-            pytest.param("1E+1021", "1" + "0" * 1021 + ".0", id="positive exponent"),
-            pytest.param("1E-1022", "0." + "0" * 1021 + "1", id="negative exponent"),
-        ),
-    )
-    def test_element_at_the_cap_is_still_normalized(self, element: str, expected: str) -> None:
-        # GIVEN a <floatstring> whose plain-notation form is exactly 1024
-        # characters — at the cap, not past it
-        assert len(expected) == 1024
-
-        # WHEN the instantiation target parses it
-        model = _parse_model(
-            model=RangeListTaskParameterDefinition, obj={"type": "FLOAT", "range": [element]}
-        )
-
-        # THEN the length bound has not cost it its normalization
-        assert [str(v) for v in model.range] == [expected]
-
-    def test_floatstring_normalization_ignores_the_decimal_context(self) -> None:
+    def test_floatstring_rendering_ignores_the_decimal_context(self) -> None:
         # GIVEN an embedding application that has narrowed the process-wide
         # decimal context, and a <floatstring> with more significant digits
         # than that precision allows
@@ -573,8 +541,8 @@ class TestRangeListElementNormalization:
                 model=RangeListTaskParameterDefinition, obj={"type": "FLOAT", "range": [element]}
             )
 
-        # THEN the value is unrounded: what this library renders is a property of
-        # the template, not of the host application's decimal context
+        # THEN it is unrounded: the rendering is a property of the template, not
+        # of the host application's decimal context
         assert [str(v) for v in model.range] == [element]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

The string form of a `<FloatRangeList>` element keeps the trailing zeros it was written with. Leading zeros still go.

```yaml
- name: Weight
  type: FLOAT
  range: ['1.5', '02.50', '3.500']   # now W:1.5 W:2.50 W:3.500  (was W:1.5 W:2.5 W:3.5)

- name: Frame
  type: INT
  range: ['1', '02', '003']          # unchanged: FRAME:1 FRAME:2 FRAME:3
```

## Why

Review on #342 made the point that the string form exists in order to carry the scale it was written with. A range element written `'2.50'` is asking for `2.50` on a command line; a renderer handed `2.5` has been given a different string. #342 normalized the element to the number it denotes and threw that away.

The two kinds of zero are not the same thing, and this splits them:

| | | |
|---|---|---|
| **Leading zeros** | not part of the number — dropped | `'02'` on an INT range is the task value `2`; forwarding the text renders `--frame 02` |
| **Trailing zeros** | the author's chosen scale — kept | `'02.50'` renders `2.50` |

This is also what lets two conformance fixtures both be right at once. The already-landed `EXPR/jobs/expr1.3.4--float-passthrough` asserts `PARAM:3.500` from a FLOAT `default: "3.500"`. `base/jobs/3.4.1.2--float-range-floatstring-elements-normalized` (in openjd-specifications#179) was written to state the opposite reading for a range element, and its own comment flagged that the two could not coexist and that a spec ruling was needed. The ruling is trailing-keep, so the range-element fixture is the one that moves.

## What this deletes, and why

A `<floatstring>` now renders as its own text less any redundant leading zeros. That is a substring operation, not a numeric one, which removes the machinery d6d5540 and e7a17b3 added — every problem those commits were solving came from having to pick a notation in which to re-render a `Decimal`:

- `normalize()` and `quantize()` round to `getcontext().prec`, so an embedding application's decimal context changed what this library rendered.
- `str(Decimal)` switches to exponent notation below `1e-6`, so `'0.0000001'` rendered `1E-7`.
- `format(value, 'f')` is exact and plain at every magnitude but unbounded in the exponent, so `'1e999999999'` — 11 characters of template text — expanded to ~10<sup>9</sup> characters and needed a length bound to stay safe.

Text needs none of those decisions. `'1e999999999'` now costs its own 11 characters, so the exponent bound and its four boundary cases go with it, and an element can no longer silently exceed `TaskParameterStringValueAsJob`'s 1024-character cap and fall through to a numeric member of the union. Net **68 insertions, 153 deletions**, one commit.

An `<intstring>` is unaffected: `int()` already discards leading zeros, and there are no fractional digits to preserve.

## Verification

**Model suite** 5527 → 5529 passed, 24 skipped, 3 xfailed. `ruff`, `black`, `mypy` clean at the CI-pinned versions.

**Conformance**, full `2023-09/*` suite (1162 fixtures) run from source — `openjd-cli` at mainline `7c7ece4`, `openjd-sessions` at `0.10.14`, which is the newest combination the CLI supports — against openjd-specifications#180's tree:

| Model | Result |
|---|---|
| baseline @ `e7a17b3` (mainline) | 1161 passed, **1 failed** — `base/jobs/7.5--numeric-string-zeros-in-range-elements` |
| this branch | **1162 passed, 0 failed** |

The one fixture that pins this rule goes green and nothing else moves. That includes both controls: `base/jobs/3.4--float-parameter` (a `<float>` numeric literal rendering `1.0`) and `EXPR/jobs/expr1.3.4--float-passthrough` (a FLOAT `default: "3.500"` rendering `3.500`) both pass.

**Mutation-checked.** Three mutants confirm the tests pin both halves of the rule rather than just asserting the current output:

| Mutant | Result |
|---|---|
| leading-zero strip removed (forward text verbatim) | 7 tests fail |
| trailing-zero strip restored (the #342 behaviour) | 7 tests fail |
| `int()` conversion removed | 3 tests fail |

## Cross-implementation agreement

openjd-rs, which also backs this package's `openjd.model._v1` API, needed the matching change: it stored a resolved FLOAT range as `Vec<f64>`, so `'02.50'` rendered `2.5`. That is OpenJobDescription/openjd-rs#354. With both branches in place the two implementations render every range-element case tested identically:

| Source | Both render |
|---|---|
| `'1.5'` `'02.50'` `'3.500'` `'007'` | `1.5` `2.50` `3.500` `7` |
| `'0.50'` `'000'` `'0.00'` | `0.50` `0` `0.00` |
| `'1E+2'` `'1e-3'` `'+2.50'` | `1E+2` `1e-3` `+2.50` |

Before the two changes they disagreed on eight of those ten.

## Review round

Five findings, all measured against 0.11.6, mainline `e7a17b3`, and this branch before acting. Two were correct and are fixed in `0708da8`; three do not hold.

| Finding | Verdict |
|---|---|
| `float()` forwards `'  1.5  '` with its spaces | **Correct, fixed.** Mainline rendered `1.5`; openjd-rs trims the resolved element, so this does too. The underscore case (`'1_0.5'`) is real but pre-existing — released 0.11.6 renders it the same way and openjd-rs rejects the template outright, so it is a template-layer parity issue, not this change's. |
| `-0.0` renders `-0.0`, diverging from openjd-rs | **Correct, fixed.** Zero has no sign; the sign is dropped without the decimal places, so `-0.0` → `0.0` and `-0.00` → `0.00`. Text that reaches zero only by underflow (`1e-400`) no longer renders a string that disagrees with the value. The `+` case needed no change: openjd-rs renders `+2.50` too, measured. |
| Dropping the length guard lets an over-cap element round through `float` | **Wrong.** Measured identical on all three checkouts (`1.2345678901234567`). The old bound ran *before* the strip, so it returned the element unchanged at 1126 characters — the strip was never reached. Pre-existing since 0.11.6. The comment that over-claimed a guarantee was reworded. |
| `'007'` → `7` reintroduces a divergence | **Stale premise.** That described openjd-rs before its matching fix: `9a9998d` rendered `7.0`, openjd-rs#354 renders `7`. The suggested fix (append `.0` when no point) would *create* the divergence. |
| Exponent notation now reaches a command line | **Not fixing.** A restoration, not a new behaviour: released 0.11.6 renders `1E+2`, and so does openjd-rs on both sides of its fix. `100.0` existed only in the two unreleased commits this PR revises, and forcing plain notation is what produced the unbounded-expansion bug. §7.5 marks it unspecified. |

## Known remaining divergence

On the FLOAT job parameter **default** surface, openjd-rs forwards the text verbatim and does not strip leading zeros: `default: '007'` renders `007` there and `7` here, and `default: '01.250'` renders `01.250` there and `1.250` here. Template Schemas §7.5 rule 1 says they should be stripped, so openjd-rs is the side that is wrong, but no conformance fixture pins it and it is a pre-existing difference on a surface this change does not touch. Left for a follow-up rather than widened into either PR.

Exponent notation and an explicit leading `+` also still differ between the two on the default surface (`'1e-3'` renders `0.001` here, `1e-3` there). §7.5 calls both out as unspecified in this revision.

## Related

- #342, d6d5540, e7a17b3 — the commits this revises. All three are unreleased; relative to 0.11.6 the only new behaviour on this branch is the leading-zero trim.
- openjd-specifications#180 — Template Schemas §7.5, which states the rule, plus the conformance fixture.
- OpenJobDescription/openjd-rs#354 — the same rule in openjd-rs.

---

## Does this revert half of #342?

Asked in review. No — it reverts one axis of #342's FLOAT behaviour, and fully reverts the two *follow-up* commits, but #342's INT behaviour, its bug fix, and its architecture all survive.

Rendered range-element values, probed against four checkouts, each built and run rather than read:

| Source | 0.11.6 (pre-#342) | #342 `f5da1b0` | mainline `e7a17b3` | this branch |
|---|---|---|---|---|
| INT `'02'` | `02` | `2` | `2` | `2` |
| INT `'003'` | `003` | `3` | `3` | `3` |
| FLOAT `'1.5'` | `1.5` | `1.5` | `1.5` | `1.5` |
| FLOAT `'02.50'` | `02.50` | `2.5` | `2.5` | **`2.50`** |
| FLOAT `'3.500'` | `3.500` | `3.5` | `3.5` | **`3.500`** |
| FLOAT `'007'` | `007` | `7` | `7.0` | **`7`** |
| FLOAT `'0.50'` | `0.50` | `0.5` | `0.5` | **`0.50`** |
| FLOAT `'0.00'` | `0.00` | `0` | `0.0` | **`0.00`** |

#342 collapsed a `<floatstring>` to the number it denotes, which dropped leading and trailing zeros in one action. Those are separable, and only the second is reverted.

**What survives from #342**

- **The INT half, entirely.** `'02'`→`2` is #342's behaviour, untouched.
- **The leading-zero trim on FLOAT.** `'02.50'`→`2.50` still loses the `0`; `'007'`→`7`.
- **The containment bug fix.** `git diff f5da1b0..HEAD -- src/openjd/model/_step_param_space_iter.py` is empty. The `range_set={str(v) for v in parameter.range}` repair and the test that pins it are exactly as #342 left them.
- **The architecture.** `_normalize_numeric_range_elements` is still a `mode="before"` validator on `RangeListTaskParameterDefinition`, in the same place, keying off the validated `type`, so it still covers all three inbound range paths.

**What is reverted in full** is `d6d5540` and `e7a17b3`, not #342. Those existed only to make re-rendering a `Decimal` safe: context-sensitive rounding, exponent notation below `1e-6`, and the unbounded `format(v, 'f')` expansion that needed a 1024-character bound. Forwarding text needs none of it. That is where the −132 lines come from, and it is also why `'007'` renders `7` rather than mainline's `7.0` — the "always keep one fractional digit" rule was a follow-up invention, not #342's.

**Proportions, from the diffs**

Source only, excluding tests:

- Against #342 itself: 30 insertions, 35 deletions, one file (`v2023_09/_model.py`).
- Against released 0.11.6: 61 insertions, 2 deletions across two files.

The sharpest statement: **relative to the last release, the only behaviour change left on this branch is the leading-zero trim.** Every cell where this branch differs from 0.11.6 is a removed leading zero. That trim is #342's contribution, kept. So #342 nets out as retained-and-narrowed rather than half-reverted; the machinery being reverted belongs to the commits that came after it.
