### PR TITLE
chore(deps): Bump openjd-* Rust crates to latest crates.io releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encoding_rs"
@@ -293,7 +293,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c92814c286f45b5ed1498ce9547bc9637b473eba7037f8aee6a4d5a3c1e051c"
+checksum = "65ec0d45986cd51c847c75c5b69a00852c4fc84d0e5e79f041173f73437d0cdf"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "is-macro"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+checksum = "8267aa6001e25494f3015f9663bbd88a18240c74483afa5f0934a1b3e4c388e9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -516,9 +516,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 dependencies = [
  "value-bag",
 ]
@@ -679,9 +679,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openjd-expr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a752942242b0ab0e5106be3bc77b75d5fe55a7fc6785d1d8619fcbd479cc8d"
+checksum = "e20c50bf19d788b8b491e87cecf7e3e0ea312ffcd17cfb2e2240ff1e64c49887"
 dependencies = [
  "regex",
  "regex-syntax",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-model"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc690053425f7975000b85fc94e638c1c25073fd8651cf5f4b08e15f18dc5b"
+checksum = "29cc8faeffd5da33c6e47c7eaff87169d9ed275292c894f950d215d99d5bfb97"
 dependencies = [
  "indexmap",
  "openjd-expr",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-sessions"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4889748a80bb727c242d3d03e2a60baef9a71fd5e548efe213c7dc581e026742"
+checksum = "4fe33608faf28b7ef2449814ad9040605775cbf5a5f7c3d30e53fcd2842b1aff"
 dependencies = [
  "bitflags",
  "futures-util",
@@ -753,18 +753,18 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "ordermap"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+checksum = "b1288aecc871a8edf4d48083fb911efe2716700ba47bee1854c03466ff3627de"
 dependencies = [
  "indexmap",
 ]
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen"
-version = "0.22.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1242a6080f45edcfaf3be3b9968914dd47a408c5590aea22770b978f7c36ffa7"
+checksum = "a267ea4da9a831f534def7f1d8e14f581d5640d3e5af6527072724f216f4dbbf"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-stub-gen-derive"
-version = "0.22.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643db6033267fd2f875fc8970d76bef247bbcdfcffe3ea5c6cd40424024f6c89"
+checksum = "6573423a5e8cc43ec7565eccccbc2dd35e1fc9032d9ca404afab875429eb8cf0"
 dependencies = [
  "heck",
  "indexmap",
@@ -1010,9 +1010,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2c6921c8ce48fb1b052b457619d008834039d80325992ed3bc55bbe6c155ad"
+checksum = "3afb591f9cdb6223c88ba39269aff895620c7f0716dc42b705b5733d5c7c0823"
 dependencies = [
  "annotate-snippets",
  "base64",
@@ -1269,7 +1269,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1345,15 +1345,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "sval"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4a2a7d92fa86fcc6222e4c3845f8486cff899d9db32480b26c91a5dbf2e22d"
+checksum = "b81b254da21fe1fcc4e3a74fe39b46e25e3a863078f8b71c954d47f84889dbc6"
 
 [[package]]
 name = "sval_buffer"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4324db9ac500c609d659b752edf9c8abbf2233f8afd61a503fd6f88ed625032"
+checksum = "50be352d2822ffafb59e3e2ddac9d5ee60f2eeadbb7b5a2a951b9f3651e87a6f"
 dependencies = [
  "sval",
  "sval_ref",
@@ -1362,18 +1362,18 @@ dependencies = [
 
 [[package]]
 name = "sval_dynamic"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4046add0eecf55e680b9e207edf5fc7737b18a1d950db363d97e7f1b2d7c629c"
+checksum = "b048ca293b998d9a45659159f94a64063791e74cdc670164943dbb434405573d"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a3486b5984a0a4f25edefcf2c2dba23654c29f63e75493b671d338bf24243"
+checksum = "e6b5888e40f80568733217f27b7317b845f463400ced36c424b1a804730e53b2"
 dependencies = [
  "itoa",
  "ryu",
@@ -1382,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da53aae7c737b5b5f1be4bcb0ff20e057bf6b2ee4e9d025560075c5830d09f95"
+checksum = "e17664d6bb6b74947afaab9d7c991caa9bf5638d4dee16fcbef637f440796049"
 dependencies = [
  "itoa",
  "ryu",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df24df43cbdc4bb8c9f5ed19d0d57dc8f60a1a4259cdce52d597fe774ad3a71f"
+checksum = "07c059969ca5ca163ea7fef6c9661758973d17691aba92abdcf5c428f4ec122c"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -1404,18 +1404,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bebc17f0f1fad060e57b778728d41ef87627e9111a6365d7463472cb58fc1b3"
+checksum = "42d6b29ff568c85c87561807f51d2adfff4b6016c6363133f7cd1652a12548f3"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.21.1"
+version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f26fe3f6a68b40e6c8d654ea48c00e4316272fddf68c80493714c1b034ae70b"
+checksum = "8f33ec9edc42b12764d5c90ca0a1d84189c6bde81ed27507f1e661c6e4e05853"
 dependencies = [
  "serde_core",
  "sval",
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1467,7 +1467,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -1715,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417d6197dd0ee696783d6be4276ac6ea74b985e00024c85ccfb37aff4f2bed82"
+checksum = "27780e3aec98b13ac796bc0d5770205ee6e976d1ccb33a52da70b73ff0ff880d"
 dependencies = [
  "erased-serde",
  "serde_core",
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f7251ecde2c9ed431bbe0659853e7991753447447bbf1ae59d8b31c578d4e"
+checksum = "1c093d229c7ead9974b640e61170976e0eff3dac447cf6792c645f0b7f28b3de"
 dependencies = [
  "sval",
  "sval_buffer",

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -402,7 +402,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ------
 
-** is-macro; version 0.3.7 -- https://crates.io/crates/is-macro
+** is-macro; version 0.3.8 -- https://crates.io/crates/is-macro
 
                                  Apache License
                            Version 2.0, January 2004
@@ -2093,19 +2093,19 @@ limitations under the License.
 ** bitflags; version 2.13.1 -- https://crates.io/crates/bitflags
 ** bstr; version 1.13.1 -- https://crates.io/crates/bstr
 ** cfg-if; version 1.0.4 -- https://crates.io/crates/cfg-if
-** either; version 1.17.0 -- https://crates.io/crates/either
+** either; version 1.18.0 -- https://crates.io/crates/either
 ** encoding_rs_io; version 0.1.8 -- https://crates.io/crates/encoding_rs_io
 ** equivalent; version 1.0.2 -- https://crates.io/crates/equivalent
 ** errno; version 0.3.14 -- https://crates.io/crates/errno
 ** hashbrown; version 0.16.1 -- https://crates.io/crates/hashbrown
 ** hashbrown; version 0.17.1 -- https://crates.io/crates/hashbrown
 ** heck; version 0.5.0 -- https://crates.io/crates/heck
-** indexmap; version 2.14.0 -- https://crates.io/crates/indexmap
+** indexmap; version 2.14.1 -- https://crates.io/crates/indexmap
 ** itertools; version 0.14.0 -- https://crates.io/crates/itertools
-** log; version 0.4.33 -- https://crates.io/crates/log
+** log; version 0.4.34 -- https://crates.io/crates/log
 ** num-traits; version 0.2.19 -- https://crates.io/crates/num-traits
 ** once_cell; version 1.21.4 -- https://crates.io/crates/once_cell
-** ordermap; version 1.2.0 -- https://crates.io/crates/ordermap
+** ordermap; version 1.2.1 -- https://crates.io/crates/ordermap
 ** pyo3-log; version 0.13.4 -- https://crates.io/crates/pyo3-log
 ** regex-automata; version 0.4.18 -- https://crates.io/crates/regex-automata
 ** regex-syntax; version 0.8.11 -- https://crates.io/crates/regex-syntax
@@ -2115,7 +2115,7 @@ limitations under the License.
 ** unicode-normalization; version 0.1.25 -- https://crates.io/crates/unicode-normalization
 ** unicode-width; version 0.2.2 -- https://crates.io/crates/unicode-width
 ** unicode_names2; version 1.3.0 -- https://crates.io/crates/unicode_names2
-** uuid; version 1.24.0 -- https://crates.io/crates/uuid
+** uuid; version 1.26.0 -- https://crates.io/crates/uuid
 ** value-bag; version 1.13.2 -- https://crates.io/crates/value-bag
 ** wasi; version 0.11.1+wasi-snapshot-preview1 -- https://crates.io/crates/wasi
                               Apache License
@@ -2530,13 +2530,13 @@ limitations under the License.
 ** arraydeque; version 0.5.1 -- https://crates.io/crates/arraydeque
 ** get-size-derive2; version 0.7.4 -- https://crates.io/crates/get-size-derive2
 ** get-size2; version 0.7.4 -- https://crates.io/crates/get-size2
-** granit-parser; version 1.0.1 -- https://crates.io/crates/granit-parser
+** granit-parser; version 1.2.0 -- https://crates.io/crates/granit-parser
 ** itoa; version 1.0.18 -- https://crates.io/crates/itoa
 ** libc; version 0.2.189 -- https://crates.io/crates/libc
 ** manyhow-macros; version 0.11.4 -- https://crates.io/crates/manyhow-macros
-** openjd-expr; version 0.4.0 -- https://crates.io/crates/openjd-expr
-** openjd-model; version 0.5.2 -- https://crates.io/crates/openjd-model
-** openjd-sessions; version 0.5.2 -- https://crates.io/crates/openjd-sessions
+** openjd-expr; version 0.5.0 -- https://crates.io/crates/openjd-expr
+** openjd-model; version 0.5.4 -- https://crates.io/crates/openjd-model
+** openjd-sessions; version 0.5.4 -- https://crates.io/crates/openjd-sessions
 ** pin-project-lite; version 0.2.17 -- https://crates.io/crates/pin-project-lite
 ** portable-atomic; version 1.15.0 -- https://crates.io/crates/portable-atomic
 ** proc-macro2; version 1.0.107 -- https://crates.io/crates/proc-macro2
@@ -2549,7 +2549,7 @@ limitations under the License.
 ** rustc-hash; version 2.1.3 -- https://crates.io/crates/rustc-hash
 ** rustversion; version 1.0.23 -- https://crates.io/crates/rustversion
 ** ryu; version 1.0.23 -- https://crates.io/crates/ryu
-** serde-saphyr; version 1.0.1 -- https://crates.io/crates/serde-saphyr
+** serde-saphyr; version 1.2.0 -- https://crates.io/crates/serde-saphyr
 ** serde; version 1.0.229 -- https://crates.io/crates/serde
 ** serde_core; version 1.0.229 -- https://crates.io/crates/serde_core
 ** serde_derive; version 1.0.229 -- https://crates.io/crates/serde_derive
@@ -2557,7 +2557,7 @@ limitations under the License.
 ** shlex; version 2.0.1 -- https://crates.io/crates/shlex
 ** siphasher; version 1.0.3 -- https://crates.io/crates/siphasher
 ** syn; version 2.0.119 -- https://crates.io/crates/syn
-** syn; version 3.0.3 -- https://crates.io/crates/syn
+** syn; version 3.0.4 -- https://crates.io/crates/syn
 ** thiserror-impl; version 2.0.20 -- https://crates.io/crates/thiserror-impl
 ** thiserror; version 2.0.20 -- https://crates.io/crates/thiserror
 ** unicode-ident; version 1.0.24 -- https://crates.io/crates/unicode-ident

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -12,16 +12,16 @@ name = "_openjd_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-openjd-expr = "0.4.0"
-openjd-model = "0.5.2"
-openjd-sessions = "0.5.2"
+openjd-expr = "0.5.0"
+openjd-model = "0.5.4"
+openjd-sessions = "0.5.4"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"
 pyo3 = { version = "0.29", features = ["abi3-py39"] }
 pyo3-log = "0.13"
 log = "0.4"
-pyo3-stub-gen = { version = "0.22", optional = true }
+pyo3-stub-gen = { version = "0.23", optional = true }
 
 [[bin]]
 name = "stub_gen"


### PR DESCRIPTION
## What changed

Bumps the bindings crate onto the current published `openjd-*` releases from
crates.io and refreshes the rest of the locked graph.

| Crate | Before | After |
|---|---|---|
| openjd-expr | 0.4.0 | 0.5.0 |
| openjd-model | 0.5.2 | 0.5.4 |
| openjd-sessions | 0.5.2 | 0.5.4 |
| pyo3-stub-gen | 0.22 | 0.23 |

`cargo update` moved 21 transitive crates to their latest compatible versions —
notably `serde-saphyr` 1.0.1 → 1.2.0, `uuid` 1.24.0 → 1.26.0, `granit-parser`
1.0.1 → 1.2.0. `THIRD-PARTY-LICENSES.txt` is regenerated with
`scripts/check_third_party_licenses.sh --update` under cargo-about 0.9.2, the
version CI installs.

`pyo3`, `pyo3-log`, `tokio`, `log`, `serde_json` and `windows` were already at
their latest published versions within the declared ranges, so no manifest change
was needed for them. `openjd-cli` is the fourth crate under the
[openjobdescription keyword](https://crates.io/keywords/openjobdescription) but is
not a dependency of this repo.

No source edits: the `openjd-expr` 0.4 → 0.5 major bump broke no call site.

## Known gap: the `stub-gen` feature still does not build

The `pyo3-stub-gen` bump does not fix the `stub-gen` feature under `abi3-py39`.
0.23.0 still calls `impl_exception_stub_type!(PyEncodingWarning, ...)` unguarded,
and pyo3 gates that type behind `#[cfg(Py_3_10)]`, which is unset for
`abi3-py39`. This break predates the bump:

| Tree | `cargo build --workspace --all-features` |
|---|---|
| e7a17b3 (base) | fails, 8 errors in pyo3-stub-gen 0.22.3 from pyo3 0.29's `downcast` → `cast` rename |
| this branch | fails, 1 error: `PyEncodingWarning` not found |

So the bump narrows the failure to exactly the upstream bug that
`scripts/generate_stubs.sh` already clones-and-patches around. CI builds default
features only (`rust_quality.yml` runs `cargo build --all-targets`, not
`--all-features`), so no gate regresses. Fixing stub generation properly needs an
upstream patch or a `[patch.crates-io]` entry, and is out of scope here.

## Verification

Run locally on macOS (aarch64, cargo 1.96.0):

- `cargo fmt --manifest-path rust-bindings/Cargo.toml --check` — clean
- `cargo build --workspace` — ok
- `cargo clippy --manifest-path rust-bindings/Cargo.toml --all-targets -- -D warnings` — clean
- `cargo test --workspace` — ok (bindings crate has no Rust tests; 0 passed)
- `cargo deny --config deny.toml check licenses bans sources` — `bans ok, licenses ok,
  sources ok`, with two `license-not-encountered` warnings for the now-unused `ISC`
  and `MIT-0` allowances in `deny.toml`
- `hatch run test` — 5517 passed, 24 skipped, 3 xfailed; coverage 94.11% against
  the 94% gate. The extension was rebuilt against openjd-expr 0.5.0,
  openjd-model 0.5.4, openjd-sessions 0.5.4 by `maturin develop`.
- `scripts/check_third_party_licenses.sh` — reports the file up to date

The same commit content ran green on all 28 CI checks on
[leongdl#1](https://github.com/leongdl/openjd-model-for-python/pull/1) before being
squashed and retargeted here, including the Linux/macOS/Windows Rust legs and the
`THIRD-PARTY-LICENSES` check that a stale local cargo-about 0.9.1 had initially
failed.
