### PR TITLE
fix: Enforce the 512-character cap on a let binding identifier

### DIFF
--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -921,6 +921,19 @@ class ScriptInterpreter(str, Enum):
 LET_MAX_BINDINGS = 50
 _LET_NAME_RE = re.compile(r"^[a-z_][A-Za-z0-9_]*$")
 
+# §3.6.1: the maximum length of a `let` binding's `<UserIdentifier>`.
+#
+# Flat 512, deliberately not the §7.1 `<Identifier>` cap that
+# `NameIdentifierLengthMixin` and the inline
+# `512 if "FEATURE_BUNDLE_1" in context.extensions else 64` checks apply. §3.6.1
+# states one maximum for a `<UserIdentifier>` and does not gate it on an
+# extension, and the conformance pair proves the flat reading:
+# `EXPR/job_templates/3.6--let-boundary-edges.yaml` declares `EXPR` alone and
+# requires a 512-character name to be accepted, so borrowing the §7.1 cap would
+# limit it to 64 and reject a template the spec permits. EXPR gates whether
+# `let` exists at all and moves neither cap.
+LET_MAX_IDENTIFIER_LEN = 512
+
 
 def parse_let_bindings(value: Any) -> list[tuple[str, str]]:
     """Parse a ``let`` field value (list of ``"name = expression"`` strings)
@@ -941,6 +954,12 @@ def parse_let_bindings(value: Any) -> list[tuple[str, str]]:
         expr = expr.strip()
         if not _LET_NAME_RE.match(name):
             raise ValueError(f"A 'let' binding name must be a valid identifier: {name!r}")
+        # The name is not interpolated into the message: at 513 characters it
+        # would dwarf the diagnostic.
+        if len(name) > LET_MAX_IDENTIFIER_LEN:
+            raise ValueError(
+                f"A 'let' binding name must be at most {LET_MAX_IDENTIFIER_LEN} characters long"
+            )
         if not expr:
             raise ValueError(f"A 'let' binding must define an expression: {binding!r}")
         result.append((name, expr))

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -921,17 +921,9 @@ class ScriptInterpreter(str, Enum):
 LET_MAX_BINDINGS = 50
 _LET_NAME_RE = re.compile(r"^[a-z_][A-Za-z0-9_]*$")
 
-# §3.6.1: the maximum length of a `let` binding's `<UserIdentifier>`.
-#
-# Flat 512, deliberately not the §7.1 `<Identifier>` cap that
-# `NameIdentifierLengthMixin` and the inline
-# `512 if "FEATURE_BUNDLE_1" in context.extensions else 64` checks apply. §3.6.1
-# states one maximum for a `<UserIdentifier>` and does not gate it on an
-# extension, and the conformance pair proves the flat reading:
-# `EXPR/job_templates/3.6--let-boundary-edges.yaml` declares `EXPR` alone and
-# requires a 512-character name to be accepted, so borrowing the §7.1 cap would
-# limit it to 64 and reject a template the spec permits. EXPR gates whether
-# `let` exists at all and moves neither cap.
+# §3.6.1: maximum length of a `let` binding's `<UserIdentifier>`. Flat, so not
+# the §7.1 cap NameIdentifierLengthMixin applies: that one is 64 without
+# FEATURE_BUNDLE_1, and a 512-character name must be accepted with EXPR alone.
 LET_MAX_IDENTIFIER_LEN = 512
 
 
@@ -954,8 +946,7 @@ def parse_let_bindings(value: Any) -> list[tuple[str, str]]:
         expr = expr.strip()
         if not _LET_NAME_RE.match(name):
             raise ValueError(f"A 'let' binding name must be a valid identifier: {name!r}")
-        # The name is not interpolated into the message: at 513 characters it
-        # would dwarf the diagnostic.
+        # Name omitted from the message; at 513 characters it would dwarf it.
         if len(name) > LET_MAX_IDENTIFIER_LEN:
             raise ValueError(
                 f"A 'let' binding name must be at most {LET_MAX_IDENTIFIER_LEN} characters long"

--- a/src/openjd/model/v2023_09/_model.py
+++ b/src/openjd/model/v2023_09/_model.py
@@ -946,10 +946,13 @@ def parse_let_bindings(value: Any) -> list[tuple[str, str]]:
         expr = expr.strip()
         if not _LET_NAME_RE.match(name):
             raise ValueError(f"A 'let' binding name must be a valid identifier: {name!r}")
-        # Name omitted from the message; at 513 characters it would dwarf it.
+        # Truncated rather than omitted: the caller is a field_validator on the
+        # whole list, so the error path is `let` with no index to identify which
+        # binding is over.
         if len(name) > LET_MAX_IDENTIFIER_LEN:
             raise ValueError(
-                f"A 'let' binding name must be at most {LET_MAX_IDENTIFIER_LEN} characters long"
+                f"A 'let' binding name must be at most {LET_MAX_IDENTIFIER_LEN} "
+                f"characters long: {name[:32]!r}... ({len(name)} characters)"
             )
         if not expr:
             raise ValueError(f"A 'let' binding must define an expression: {binding!r}")

--- a/test/openjd/model_v0/v2023_09/test_let_bindings.py
+++ b/test/openjd/model_v0/v2023_09/test_let_bindings.py
@@ -45,20 +45,24 @@ class TestLetValid:
     # EXPR alone, since the cap does not depend on FEATURE_BUNDLE_1.
     def test_name_512_chars(self):
         name = "a" * 512
-        _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}]))
+        # Referenced, not just declared: a cap further down the path would
+        # otherwise be invisible here.
+        _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun(f"{{{{{name}}}}}")}]))
 
     def test_name_512_chars_with_fb1(self):
         name = "a" * 512
         _decode(
             _job(
-                [{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}],
+                [{"name": "S", "let": [f"{name} = 1"], "script": _onrun(f"{{{{{name}}}}}")}],
                 extensions=("EXPR", "FEATURE_BUNDLE_1"),
             )
         )
 
     def test_name_512_chars_script(self):
         name = "a" * 512
-        _decode(_job([{"name": "S", "script": {"let": [f"{name} = 1"], **_onrun("hi")}}]))
+        _decode(
+            _job([{"name": "S", "script": {"let": [f"{name} = 1"], **_onrun(f"{{{{{name}}}}}")}}])
+        )
 
     def test_chained_and_functions(self):
         _decode(

--- a/test/openjd/model_v0/v2023_09/test_let_bindings.py
+++ b/test/openjd/model_v0/v2023_09/test_let_bindings.py
@@ -121,8 +121,18 @@ class TestLetInvalid:
     # alone, so these pin the cap independently of FEATURE_BUNDLE_1.
     def test_name_513_chars(self):
         name = "a" * 513
-        with pytest.raises(DecodeValidationError, match="at most 512 characters"):
+        with pytest.raises(
+            DecodeValidationError,
+            match=r"at most 512 characters long: 'a{32}'\.\.\. \(513 characters\)",
+        ):
             _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}]))
+
+    def test_name_513_chars_names_the_offending_binding(self):
+        # The validator is a field_validator on the whole list, so the error path
+        # is `let` with no index; the message has to identify the binding itself.
+        name = "b" * 513
+        with pytest.raises(DecodeValidationError, match=r"'b{32}'\.\.\. \(513 characters\)"):
+            _decode(_job([{"name": "S", "let": ["ok = 1", f"{name} = 2"], "script": _onrun("hi")}]))
 
     def test_name_513_chars_with_fb1(self):
         name = "a" * 513

--- a/test/openjd/model_v0/v2023_09/test_let_bindings.py
+++ b/test/openjd/model_v0/v2023_09/test_let_bindings.py
@@ -41,8 +41,8 @@ class TestLetValid:
             _job([{"name": "S", "script": {"let": ["a = 2"], **_onrun("{{a}}")}}]),
         )
 
-    # §3.6.1 boundary: 512 characters is the maximum and must be accepted. With
-    # EXPR alone, because the cap does not depend on FEATURE_BUNDLE_1.
+    # §3.6.1 boundary: 512 characters is the maximum and must be accepted, with
+    # EXPR alone, since the cap does not depend on FEATURE_BUNDLE_1.
     def test_name_512_chars(self):
         name = "a" * 512
         _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}]))
@@ -117,12 +117,8 @@ class TestLetInvalid:
         with pytest.raises(DecodeValidationError, match="cannot reference itself"):
             _decode(_job([{"name": "S", "let": ["x = x + 1"], "script": _onrun("hi")}]))
 
-    # §3.6.1: a `<UserIdentifier>` is at most 512 characters. The cap is flat,
-    # not the FEATURE_BUNDLE_1-gated §7.1 `<Identifier>` cap, so the accept case
-    # must hold with EXPR alone. `_job` declares EXPR only by default, which is
-    # what the conformance fixture
-    # `EXPR/job_templates/3.6--let-boundary-edges.yaml` asserts; the
-    # `_with_fb1` variants pin that declaring FEATURE_BUNDLE_1 does not move it.
+    # §3.6.1 caps a `<UserIdentifier>` at 512 characters. `_job` declares EXPR
+    # alone, so these pin the cap independently of FEATURE_BUNDLE_1.
     def test_name_513_chars(self):
         name = "a" * 513
         with pytest.raises(DecodeValidationError, match="at most 512 characters"):

--- a/test/openjd/model_v0/v2023_09/test_let_bindings.py
+++ b/test/openjd/model_v0/v2023_09/test_let_bindings.py
@@ -41,6 +41,25 @@ class TestLetValid:
             _job([{"name": "S", "script": {"let": ["a = 2"], **_onrun("{{a}}")}}]),
         )
 
+    # §3.6.1 boundary: 512 characters is the maximum and must be accepted. With
+    # EXPR alone, because the cap does not depend on FEATURE_BUNDLE_1.
+    def test_name_512_chars(self):
+        name = "a" * 512
+        _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}]))
+
+    def test_name_512_chars_with_fb1(self):
+        name = "a" * 512
+        _decode(
+            _job(
+                [{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}],
+                extensions=("EXPR", "FEATURE_BUNDLE_1"),
+            )
+        )
+
+    def test_name_512_chars_script(self):
+        name = "a" * 512
+        _decode(_job([{"name": "S", "script": {"let": [f"{name} = 1"], **_onrun("hi")}}]))
+
     def test_chained_and_functions(self):
         _decode(
             _job(
@@ -97,6 +116,34 @@ class TestLetInvalid:
         # its definition point). Mirrors openjd-rs "references itself".
         with pytest.raises(DecodeValidationError, match="cannot reference itself"):
             _decode(_job([{"name": "S", "let": ["x = x + 1"], "script": _onrun("hi")}]))
+
+    # §3.6.1: a `<UserIdentifier>` is at most 512 characters. The cap is flat,
+    # not the FEATURE_BUNDLE_1-gated §7.1 `<Identifier>` cap, so the accept case
+    # must hold with EXPR alone. `_job` declares EXPR only by default, which is
+    # what the conformance fixture
+    # `EXPR/job_templates/3.6--let-boundary-edges.yaml` asserts; the
+    # `_with_fb1` variants pin that declaring FEATURE_BUNDLE_1 does not move it.
+    def test_name_513_chars(self):
+        name = "a" * 513
+        with pytest.raises(DecodeValidationError, match="at most 512 characters"):
+            _decode(_job([{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}]))
+
+    def test_name_513_chars_with_fb1(self):
+        name = "a" * 513
+        with pytest.raises(DecodeValidationError, match="at most 512 characters"):
+            _decode(
+                _job(
+                    [{"name": "S", "let": [f"{name} = 1"], "script": _onrun("hi")}],
+                    extensions=("EXPR", "FEATURE_BUNDLE_1"),
+                )
+            )
+
+    def test_name_513_chars_script(self):
+        name = "a" * 513
+        with pytest.raises(DecodeValidationError, match="at most 512 characters"):
+            _decode(
+                _job([{"name": "S", "script": {"let": [f"{name} = 1"], **_onrun("hi")}}]),
+            )
 
     def test_comprehension_shadows_let(self):
         with pytest.raises(DecodeValidationError, match="shadows"):


### PR DESCRIPTION
## What

Template Schemas §3.6.1 caps a `let` binding's `<UserIdentifier>` at 512 characters. Nothing checked it, so a 513-character name was accepted.

```yaml
steps:
- name: Step1
  let:
  - aaa…aaa = 42        # 513 characters: now rejected
  - aaa…aaa = 42        # 512 characters: still accepted
```

```
A 'let' binding name must be at most 512 characters long
```

## Why

The conformance fixture pinning this is [`EXPR/job_templates/proposed/3.6.1--let-identifier-513.invalid.yaml`](https://github.com/OpenJobDescription/openjd-specifications/pull/164), added by openjd-specifications#164. It fails on this implementation and on openjd-rs alike. I found it while running every open conformance-test PR against both implementations, each built from source; it is root cause F-6 of that sweep.

Spec text, pinned at the commit the sweep measured against — [wiki/2023-09-Template-Schemas.md, L1424-L1454](https://github.com/OpenJobDescription/openjd-specifications/blob/563c6ec9c4fc7d0756d35ab8d56ef652179912b9/wiki/2023-09-Template-Schemas.md?plain=1#L1424-L1454):

```bnf
<UserIdentifier> ::= [a-z_][A-Za-z0-9_]*
```

> 3. Maximum length of `<UserIdentifier>`: 512 characters.

That is L1430 and L1441. The section states one maximum and does not gate it on any extension.

## Why this does not reuse the §7.1 identifier cap

This is the decision worth reviewing, because reaching for the existing cap is the obvious move and it is wrong here.

This package already carries the §7.1 `<Identifier>` cap in `NameIdentifierLengthMixin` and in seven inline `512 if "FEATURE_BUNDLE_1" in context.extensions else 64` checks. That cap is 64 characters, rising to 512 with `FEATURE_BUNDLE_1`. §3.6.1's `<UserIdentifier>` is a different type with a flat maximum.

The conformance pair proves the flat reading rather than merely suggesting it. The 512-character accept twin, `EXPR/job_templates/3.6--let-boundary-edges.yaml` from openjd-specifications#160, declares `extensions: [EXPR]` with no `FEATURE_BUNDLE_1`. Under the §7.1 cap its limit would be 64, so a fix built on that cap would reject a template the spec permits and turn a passing fixture red.

The two caps share the number 512 and nothing else, so this adds `LET_MAX_IDENTIFIER_LEN` beside the existing `LET_MAX_BINDINGS`, carrying its own citation and a comment recording why it is not the other one. EXPR gates whether `let` exists at all and moves neither cap.

## Where the check goes, and why one place is enough

Four models carry a `let` field, and all four `_validate_let` field validators route through `validate_let_field` and then `parse_let_bindings`. The check therefore goes in `parse_let_bindings`, immediately after the `_LET_NAME_RE` match, and every scope is covered by one insertion.

The message omits the offending name, because at 513 characters it would dwarf the diagnostic.

The runtime helper `evaluate_let_bindings` is left alone. It runs on templates validation has already accepted, so rejecting there would surface too late.

## Verification

Full suite: 5531 passed, 24 skipped, 3 xfailed. `ruff check` and `mypy` clean. `ruff format --check` reports both files I touched as already formatted.

Two pre-existing failures are unrelated to this change: `TestYAMLLoaderPerformance::test_extra_large_template_performance` in both `model_v0` and `model_v1` asserts a hard 5x speedup and lands at 4.0x-4.9x on my machine. I confirmed they are pre-existing by stashing this change and re-running on unmodified `mainline`, where both still fail, at 4.0x and 4.2x.

Six new tests in `test/openjd/model_v0/v2023_09/test_let_bindings.py`: 513 rejected and 512 accepted, each at step scope and script scope, plus both cases with `FEATURE_BUNDLE_1` declared. The file's `_job` helper declares EXPR alone by default, so the default variants are the ones that pin the section above; without them a regression to the `FEATURE_BUNDLE_1`-gated cap would pass the suite.

**Mutation-checked.** Removing the production check fails all three reject tests and leaves all three accept tests passing, so the accept cases act as negative controls against a cap set too low.

| Mutant | Result |
|---|---|
| length check removed | 3 reject tests fail, 20 pass |

I cleared `__pycache__` between runs and confirmed the mutated tree still imports, so the failures are the assertion firing rather than a broken build.

## Out of scope

The §3.6.1 minimum length of 1 character. `_LET_NAME_RE` already rejects an empty name, and the conformance suite covers it.

## Related

- openjd-specifications#164 — the fixture, currently parked in `proposed/`. It can move out once both implementations release the fix.
- The matching openjd-rs change: OpenJobDescription/openjd-rs#358
- Design note: `SuperDaveDocs docs/conformance-0901/4.6-let-513/fix.md`
