### PR TITLE
ci: Watch cargo deps with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,36 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "cargo"
+    directory: "/" # Workspace root; rust-bindings is discovered as a member
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    # openjd-* minor bumps get a PR each: they are 0.x, where cargo treats a
+    # minor as breaking, and they carry the API surface these bindings wrap.
+    # Everything else is grouped — tokio, uuid and serde_json are 1.x, where a
+    # minor is additive, and transitive Cargo.lock bumps are noise.
+    #
+    # Every cargo PR needs `scripts/check_third_party_licenses.sh --update`
+    # committed onto its branch: that check renders crate versions from
+    # Cargo.lock and dependabot cannot regenerate it.
+    groups:
+      # Matched first, so an openjd-* patch groups here and only minors reach
+      # the exclusion below. Majors match no group and so get a PR each.
+      cargo-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      cargo-minor:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "openjd-*"
+        update-types:
+          - "minor"
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Supersedes #336, which is rebased onto a two-week-old mainline and carries a factually wrong
justification. Close that one in favour of this.

Dependabot watches `pip` and `github-actions` but not `cargo`, so a new `openjd-expr` /
`openjd-model` / `openjd-sessions` release is only noticed when somebody goes looking.
[#335](https://github.com/OpenJobDescription/openjd-model-for-python/pull/335) is the worked
example: the crates published, and picking them up was a manual chase for pins, `Cargo.lock`, and
`THIRD-PARTY-LICENSES.txt`. This makes that arrive as a PR on its own.

### What lands where

Two groups, ordered. Dependabot places a dependency in the first group it matches, and anything
matching no group gets its own PR.

| Bump | Lands as |
|---|---|
| `openjd-model` 0.6.0 -> 0.6.1 | grouped in `cargo-patch` |
| `tokio` 1.53 -> 1.54 | grouped in `cargo-minor` |
| `openjd-expr` 0.6 -> 0.7 | **its own PR** |
| any major | its own PR |

The isolation is for the `openjd-*` crates specifically. They are 0.x, where cargo treats a minor
as breaking, and they carry the API surface these bindings wrap: `openjd-expr` 0.4.0 carried a
breaking coercion change, and `openjd-model` 0.5.2 changed the job-side `StepScript` wire format.
Those deserve their own CI run and their own review rather than riding along with a patch.

Everything else groups. `tokio`, `uuid` and `serde_json` are 1.x, where a minor is additive by
cargo's own rules, so isolating them buys nothing; the same goes for the 0.x crates this package
does not wrap (`pyo3`, `log`, `windows`) and for transitive `Cargo.lock` bumps, which cargo's
`dependency-type: indirect` support means dependabot will raise.

### Loosening the version requirements would not have helped

Worth stating because it is the obvious alternative. The requirements are already permissive
enough — `openjd-model = "0.6.0"` is `^0.6.0`, so `>=0.6.0, <0.7.0`, and a 0.6.1 satisfies it
without an edit. `Cargo.lock` is what actually pins the build, and it is committed and is what CI
resolves from. So a patch pickup needs a `cargo update` and a commit no matter how loose the
requirement string is, and a `*` requirement would buy nothing while giving up the reproducibility
the lock exists for.

### The one manual step this leaves

`scripts/check_third_party_licenses.sh` renders crate versions out of `Cargo.lock` and hard-fails
on any diff, so the `third_party_licenses` check will be red on every cargo PR until the file is
regenerated [measured — a lock-only diff of the three openjd versions failed the check]. The
follow-up is one command pushed to the dependabot branch:

```bash
scripts/check_third_party_licenses.sh --update
```

That note now lives in `dependabot.yml` rather than only in this description, so it is findable
after the PR is merged.

**This check is already non-hermetic, independently of cargo.** The Python section is regenerated
by *resolving* `pyproject.toml` into a fresh venv, and `pyproject.toml` declares
`pydantic >= 2.10, < 3` — unpinned. The committed file records `pydantic; version 2.13.5`, which is
what PyPI serves today, so the check is green by coincidence of timing. The next pydantic patch
release turns `third_party_licenses` red on every PR from every author. Fixing that properly (a
regenerate-and-commit job that works for any author, or making the check advisory) is worth its own
PR and would subsume the cargo case; gating the check on `dependabot[bot]` would not, because it
leaves the Python side untouched.

Note the zero-touch option is not as cheap as it looks: a dependabot `pull_request` gets a
read-only token, so committing back needs `pull_request_target` or a PAT, and the script builds a
wheel from PR head — that is a write-capable token running PR-authored build code.

### Review findings from #336

| Finding | Verdict | Disposition |
|---|---|---|
| The `pre-1.0` justification is wrong | **Correct** | Fixed here. `tokio`, `uuid` and `serde_json` are 1.x. The comment no longer claims otherwise, and `cargo-minor` groups them. |
| `auto_approve.yml` approves every dependabot PR, including breaking 0.x minors | **Correct** | Not fixed here; it is a one-line change to a different file that also changes behaviour for the existing pip and github-actions PRs. Raised separately. |
| The license check will redden every cargo PR | **Correct, and known** | Documented above and now in `dependabot.yml`. Deliberately not fixed here — see the non-hermetic note. |

On the grouping fix specifically: the review suggested a `cargo-stable-minor` group listing
`["tokio", "uuid", "serde_json"]`. That does not reach the transitive 1.x crates in `Cargo.lock`
(`memchr` 2.x and friends), which is where most of the churn it objects to comes from. Inverting it
— group all minors, exclude `openjd-*` — covers those and states the intent directly.

### Testing

Config parses as YAML and declares all three ecosystems; the `cargo` entry's `directory: "/"` is
where `Cargo.toml` and `Cargo.lock` actually live, with `rust-bindings` picked up as a workspace
member.

Routing was checked by simulating dependabot's documented rules (first matching group wins;
unmatched dependencies get their own PR) over 19 cases: `openjd-*` minors and patches, every 1.x
and 0.x direct dep, two transitive crates, and majors. All 19 route as intended. Run against the
single-group config from #336, the same check fails 10 cases — including `tokio`, `uuid` and
`serde_json` minors — which confirms the second group is load-bearing rather than decorative.

Dependabot itself cannot be run locally, so the schedule and the real grouping behaviour are
unverified until it runs on a Monday.
