### PR TITLE
chore: bump openjd crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-model"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f9668a4b5663ce7897d34c4d3294b214b499c84360dc88ce2d2dedc444fad3"
+checksum = "dafcc75b2f46fbc178dd89d868667ac7e4c4a807e7f55387ae5b7e98c60031f3"
 dependencies = [
  "indexmap",
  "openjd-expr",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-sessions"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2f96d8fe1e21d255c34cd466d4619d4f809e5105e01fc6f03463a34194fe2c"
+checksum = "dfa69de3cd3585885379735b7eaf90bcba315bd4a99beea77ada191e7947c15c"
 dependencies = [
  "bitflags",
  "futures-util",

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -2535,8 +2535,8 @@ limitations under the License.
 ** libc; version 0.2.189 -- https://crates.io/crates/libc
 ** manyhow-macros; version 0.11.4 -- https://crates.io/crates/manyhow-macros
 ** openjd-expr; version 0.6.0 -- https://crates.io/crates/openjd-expr
-** openjd-model; version 0.6.0 -- https://crates.io/crates/openjd-model
-** openjd-sessions; version 0.5.5 -- https://crates.io/crates/openjd-sessions
+** openjd-model; version 0.6.1 -- https://crates.io/crates/openjd-model
+** openjd-sessions; version 0.5.6 -- https://crates.io/crates/openjd-sessions
 ** pin-project-lite; version 0.2.17 -- https://crates.io/crates/pin-project-lite
 ** portable-atomic; version 1.15.0 -- https://crates.io/crates/portable-atomic
 ** proc-macro2; version 1.0.107 -- https://crates.io/crates/proc-macro2

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 openjd-expr = "0.6.0"
-openjd-model = "0.6.0"
-openjd-sessions = "0.5.5"
+openjd-model = "0.6.1"
+openjd-sessions = "0.5.6"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"


### PR DESCRIPTION
Bump openjd-rs crate dependencies to latest published versions:
- openjd-model: 0.6.0 → 0.6.1
- openjd-sessions: 0.5.5 → 0.5.6

openjd-expr already at 0.6.0 on mainline.

### How was this change tested?

- `cargo build --all-targets` ✅
- `cargo clippy -D warnings` ✅
- `hatch run test` — 5702 passed, 94.25% coverage ✅
- `hatch run lint` ✅