### PR TITLE
chore(deps): Bump openjd-* Rust crates to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,9 +679,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openjd-expr"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05a6e060a42d2b5f681ade212f38482c5fadd460fd73dbc12ebf964828bc290"
+checksum = "b6e97fab933bcfb13e42a45d1f39311149508c454b21bf931274e288583d4e08"
 dependencies = [
  "regex",
  "regex-syntax",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-model"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dafcc75b2f46fbc178dd89d868667ac7e4c4a807e7f55387ae5b7e98c60031f3"
+checksum = "fdfffa82b1dbb94865d10c935cd547b4319932280f37b87db475dca961b7ef91"
 dependencies = [
  "indexmap",
  "openjd-expr",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "openjd-sessions"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa69de3cd3585885379735b7eaf90bcba315bd4a99beea77ada191e7947c15c"
+checksum = "877446585bd38cff6a40c68293f62b2147e5fa4f0997a83a39c5d2af38585449"
 dependencies = [
  "bitflags",
  "futures-util",

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -2534,9 +2534,9 @@ limitations under the License.
 ** itoa; version 1.0.18 -- https://crates.io/crates/itoa
 ** libc; version 0.2.189 -- https://crates.io/crates/libc
 ** manyhow-macros; version 0.11.4 -- https://crates.io/crates/manyhow-macros
-** openjd-expr; version 0.6.0 -- https://crates.io/crates/openjd-expr
-** openjd-model; version 0.6.1 -- https://crates.io/crates/openjd-model
-** openjd-sessions; version 0.5.6 -- https://crates.io/crates/openjd-sessions
+** openjd-expr; version 0.7.0 -- https://crates.io/crates/openjd-expr
+** openjd-model; version 0.7.0 -- https://crates.io/crates/openjd-model
+** openjd-sessions; version 0.5.7 -- https://crates.io/crates/openjd-sessions
 ** pin-project-lite; version 0.2.17 -- https://crates.io/crates/pin-project-lite
 ** portable-atomic; version 1.15.0 -- https://crates.io/crates/portable-atomic
 ** proc-macro2; version 1.0.107 -- https://crates.io/crates/proc-macro2

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -12,9 +12,9 @@ name = "_openjd_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-openjd-expr = "0.6.0"
-openjd-model = "0.6.1"
-openjd-sessions = "0.5.6"
+openjd-expr = "0.7.0"
+openjd-model = "0.7.0"
+openjd-sessions = "0.5.7"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1"

--- a/rust-bindings/src/expr/format_string.rs
+++ b/rust-bindings/src/expr/format_string.rs
@@ -106,8 +106,15 @@ impl PyFormatString {
     /// checking through the expression tree.
     ///
     /// Mirrors the Rust crate's
-    /// `FormatString::validate_expressions(symtab, lib)`. Returns
-    /// `None` on success.
+    /// `FormatString::validate_expressions(symtab, lib, target_type)`.
+    /// Returns `None` on success.
+    ///
+    /// `target_type` is passed as `None` because `resolve` and
+    /// `resolve_string` above resolve without one; validation has to
+    /// observe the same values resolution will produce. The crate
+    /// returns a `StaticResolution` (resolved-length bound and, when
+    /// fully concrete, the resolved value); this binding is pass/fail
+    /// only and discards it.
     #[pyo3(signature = (symtab, *, profile=None))]
     fn validate_expressions(
         &self,
@@ -117,7 +124,8 @@ impl PyFormatString {
         let st = extract_symtab(symtab)?;
         let lib = profile_for_call(profile);
         self.inner
-            .validate_expressions(&st, &lib)
+            .validate_expressions(&st, &lib, None)
+            .map(|_| ())
             .map_err(format_string_validation_err_to_py)
     }
 

--- a/specs/python-expr-interface.md
+++ b/specs/python-expr-interface.md
@@ -816,7 +816,11 @@ except FormatStringValidationError as e:
 The error message embeds the ``[start, end]`` byte offsets of the
 failing ``{{...}}`` pair so callers can produce structured
 diagnostics or syntax-highlight the failing segment. Mirrors the
-Rust crate's ``FormatString::validate_expressions(symtab, lib)``.
+Rust crate's
+``FormatString::validate_expressions(symtab, lib, target_type)``,
+which the binding calls with ``target_type=None`` to match ``resolve``
+and ``resolve_string``. The crate returns a ``StaticResolution``; the
+binding is pass/fail only and discards it.
 
 **Equality and hashability.** `FormatString` implements `__eq__` and
 `__hash__` on the raw source string. Two format strings compare equal

--- a/src/openjd/_openjd_rs.pyi
+++ b/src/openjd/_openjd_rs.pyi
@@ -915,8 +915,15 @@ class FormatString:
         checking through the expression tree.
 
         Mirrors the Rust crate's
-        `FormatString::validate_expressions(symtab, lib)`. Returns
-        `None` on success.
+        `FormatString::validate_expressions(symtab, lib, target_type)`.
+        Returns `None` on success.
+
+        `target_type` is passed as `None` because `resolve` and
+        `resolve_string` above resolve without one; validation has to
+        observe the same values resolution will produce. The crate
+        returns a `StaticResolution` (resolved-length bound and, when
+        fully concrete, the resolved value); this binding is pass/fail
+        only and discards it.
         """
 
     def __str__(self) -> builtins.str: ...

--- a/test/openjd/expr/test_expression_value.py
+++ b/test/openjd/expr/test_expression_value.py
@@ -337,27 +337,127 @@ class TestExprValueRepr:
 
     @pytest.mark.parametrize("pf", [PathFormat.POSIX, PathFormat.WINDOWS])
     def test_repr_list_path_with_format(self, pf: PathFormat) -> None:
-        import re
-
         v = ExprValue(["/a", "/b"], type="list[path]", path_format=pf)
-        r = repr(v)
-        assert re.match(
-            r"ExprValue\(\['(/|\\)a', '(/|\\)b'\], type='list\[path\]', "
-            rf"path_format=PathFormat\.{pf.name}\)",
-            r,
+        # Under WINDOWS the leading "/" normalises to "\", which the
+        # literal must escape -- so the expectation comes from CPython's
+        # repr of the normalised items rather than a regex that would
+        # accept either spelling. openjd-rs#374; before it, the WINDOWS
+        # case emitted '\a', which Python parses as BEL.
+        assert repr(v) == (
+            f"ExprValue({v.item()!r}, type='list[path]', path_format=PathFormat.{pf.name})"
         )
+        assert eval(repr(v)) == v
 
     @pytest.mark.parametrize("pf", [PathFormat.POSIX, PathFormat.WINDOWS])
     def test_repr_list_list_path_with_format(self, pf: PathFormat) -> None:
-        import re
-
         v = ExprValue([["/a"], ["/b"]], type="list[list[path]]", path_format=pf)
-        r = repr(v)
-        assert re.match(
-            r"ExprValue\(\[\['(/|\\)a'\], \['(/|\\)b'\]\], type='list\[list\[path\]\]', "
-            rf"path_format=PathFormat\.{pf.name}\)",
-            r,
+        assert repr(v) == (
+            f"ExprValue({v.item()!r}, type='list[list[path]]', path_format=PathFormat.{pf.name})"
         )
+        assert eval(repr(v)) == v
+
+
+class TestExprValueReprEscaping:
+    """``__repr__`` escapes its embedded Python literal.
+
+    ``repr_python`` previously escaped nothing, not even the quote or the
+    backslash, so a value carrying a quote, a backslash or a control
+    character produced a literal CPython cannot parse (a raw newline
+    terminates the string; a NUL cannot appear in source at all) or, worse,
+    one that parses as a different value (``'a\\b'`` is a backspace).
+    Fixed upstream in openjd-rs#374, reachable here via ``__repr__``.
+
+    Expression Language 2.2.6 defines the escaping as following Python's
+    own ``repr``, so ``repr(str)`` is the oracle rather than a hand-written
+    expectation.
+    """
+
+    # Quotes and backslashes (delimiter selection and doubling), the C0
+    # controls, DEL, and the non-ASCII characters CPython escapes by
+    # category -- U+0085, U+00A0, U+00AD, U+2028, U+2029, U+3000, U+200B,
+    # a private-use character and an astral non-printable -- alongside
+    # printable non-ASCII that must survive verbatim.
+    ESCAPING_CASES = [
+        "it's",
+        'say "hi"',
+        'it\'s a "x"',
+        "'",
+        "a\\b",
+        "a\\",
+        "\\'",
+        "hello\nworld",
+        "a\rb",
+        "a\r\nb",
+        "a\tb",
+        "a\x00b",
+        "a\x1bb",
+        "a\x7fb",
+        "a\x0b\x0cb",
+        "café",
+        "a\U0001f600b",
+        "a\x85b",
+        "a\xa0b",
+        "a\xadb",
+        "a\u2028b",
+        "a\u2029b",
+        "a\u3000b",
+        "a\u200bb",
+        "a b",
+        "a\ue000b",
+        "a\U00100000b",
+        "a\U000e0100b",
+    ]
+
+    @pytest.mark.parametrize("s", ESCAPING_CASES)
+    def test_repr_string_matches_cpython(self, s: str) -> None:
+        assert repr(ExprValue(s)) == f"ExprValue({s!r})"
+
+    @pytest.mark.parametrize("s", ESCAPING_CASES)
+    def test_repr_string_round_trips(self, s: str) -> None:
+        # The point of escaping: the literal parses back to the value.
+        assert eval(repr(ExprValue(s))) == ExprValue(s)
+
+    @pytest.mark.parametrize("s", ESCAPING_CASES)
+    def test_repr_list_element_matches_cpython(self, s: str) -> None:
+        # ``repr_python_list`` renders elements through the same writer; a
+        # list-only regression would go unnoticed by the scalar cases.
+        assert repr(ExprValue([s])) == f"ExprValue({[s]!r}, type='list[string]')"
+
+    def test_repr_list_selects_delimiter_per_element(self) -> None:
+        # CPython picks a delimiter per element, so these two differ.
+        assert repr(ExprValue(["it's", "a\nb"])) == (
+            "ExprValue([\"it's\", 'a\\nb'], type='list[string]')"
+        )
+
+    def test_repr_nested_list_element_escaped(self) -> None:
+        assert repr(ExprValue([["a\nb"]])) == r"ExprValue([['a\nb']], type='list[list[string]]')"
+
+    def test_repr_path_escaped(self) -> None:
+        v = ExprValue("/tmp/a\nb.txt", type="path", path_format=PathFormat.POSIX)
+        assert repr(v) == r"ExprValue('/tmp/a\nb.txt', type='path', path_format=PathFormat.POSIX)"
+
+    def test_repr_list_path_escaped(self) -> None:
+        # ``String`` and ``Path`` share one match arm; splitting them would
+        # leave ``list[path]`` unescaped.
+        v = ExprValue(["/a\nb"], type="list[path]", path_format=PathFormat.POSIX)
+        assert repr(v) == r"ExprValue(['/a\nb'], type='list[path]', path_format=PathFormat.POSIX)"
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (42, "ExprValue(42)"),
+            (True, "ExprValue(True)"),
+            (None, "ExprValue(None)"),
+            (Decimal("3.500"), "ExprValue('3.500', type='float')"),
+        ],
+    )
+    def test_repr_non_string_text_unaltered(self, value: object, expected: str) -> None:
+        # Negative control: numeric and keyword text needs no escaping, so
+        # routing it through the shared writer must not change it.
+        assert repr(ExprValue(value)) == expected
+
+    def test_repr_range_expr_unaltered(self) -> None:
+        assert repr(ExprValue("1-5", type="range_expr")) == "ExprValue('1-5', type='range_expr')"
 
 
 class TestMemorySize:

--- a/test/openjd/expr/test_expression_value.py
+++ b/test/openjd/expr/test_expression_value.py
@@ -377,6 +377,12 @@ class TestExprValueReprEscaping:
     # category -- U+0085, U+00A0, U+00AD, U+2028, U+2029, U+3000, U+200B,
     # a private-use character and an astral non-printable -- alongside
     # printable non-ASCII that must survive verbatim.
+    #
+    # "a b" is the negative half of the Zs discrimination: U+0020,
+    # U+00A0 and U+3000 are all Zs, and CPython escapes only the latter
+    # two. It is the case that isolates that distinction -- the quote
+    # cases above also carry a U+0020, but they vary the delimiter at
+    # the same time.
     ESCAPING_CASES = [
         "it's",
         'say "hi"',


### PR DESCRIPTION
## What changed

Bumps the three `openjd-*` Rust crate pins in `rust-bindings/Cargo.toml`, refreshes `Cargo.lock`, and regenerates `THIRD-PARTY-LICENSES.txt`:

| Crate | From | To |
|---|---|---|
| `openjd-expr` | 0.6.0 | 0.7.0 |
| `openjd-model` | 0.6.1 | 0.7.0 |
| `openjd-sessions` | 0.5.6 | 0.5.7 |

`cargo update` moved only these three packages, so the license file changes by exactly three lines and no new transitive dependency appears.

## Upstream changes and how each was verified

The claimed change list came from the release commits, then was reconciled against a source diff of the published crates. That diff surfaced one thing the changelog did not mention: #373 also added a third parameter to `validate_expressions`.

**openjd-rs#374 — `repr_py` / `repr_python` escape control characters.** Reachable here through `ExprValue.__repr__`. Before the bump, a value carrying a quote, a backslash or a control character produced a literal CPython cannot parse (a raw newline terminates the string; a NUL cannot appear in source at all) or, worse, one that parses as a different value — `'a\b'` is a backspace.

Verified through the Python binding on 28 inputs using CPython's own `repr()` as the oracle, which is the contract Expression Language 2.2.6 states for `repr_py`. All pass, including the scalar, `list[string]`, `list[path]` and nested-list paths.

**openjd-rs#373 — `FormatString::validate_expressions` returns `StaticResolution`.** This is the breaking change the minor bump carries, and it broke the build:

```
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
error[E0308]: expected `Result<(), PyErr>`, found `Result<StaticResolution, PyErr>`
```

The binding now passes `target_type: None` — matching the `resolve` and `resolve_string` methods above, which resolve without a target type, so validation observes exactly the values resolution will produce — and discards the returned `StaticResolution`. The Python method is unchanged: pass/fail, returning `None` on success. Exposing the resolved-length bound to Python is a separate feature and is not part of this bump.

**openjd-rs#369 — bound child output reading in the Windows session helper runner.** Not reachable from this repo's tests: it lives in `openjd-sessions`' helper binary, needs a live Windows session, and `subprocess.rs` is the forwarding call site. Its coverage lives upstream in openjd-rs. Called out as unverified here rather than implied.

## Tests

`TestExprValueReprEscaping` pins the #374 behaviour: quotes and backslashes (delimiter selection and doubling), the C0 controls, DEL, and the non-ASCII characters CPython escapes by category — U+0085, U+00A0, U+00AD, U+2028, U+2029, U+3000, U+200B, a private-use character and an astral non-printable — alongside printable non-ASCII that must survive verbatim. Each case is asserted three ways: against CPython's `repr()`, as an `eval(repr(v)) == v` round-trip, and as a `list[string]` element. Negative controls confirm numeric and keyword text passes through unaltered.

Mutation-checked by reverting the version pins (and the `validate_expressions` adaptation they force), rebuilding the extension, and re-running: **60 failed, 33 passed**. The tests pin real behaviour rather than restating it. The mutated tree was confirmed to build and import first, so the failure is the behaviour change and not a broken build.

## Two pre-existing tests changed, and why that is not a regression

`test_repr_list_path_with_format` and `test_repr_list_list_path_with_format` failed after the bump. They had pinned the old bug. Under `PathFormat.WINDOWS` the leading `/` normalises to `\`, and the old repr emitted `'\a'` — which Python parses as BEL, not backslash-`a`. Their regex `'(/|\\)a'` accepted that spelling.

Both now assert the escaped spelling via CPython's `repr()` of the normalised items, and additionally assert `eval(repr(v)) == v`, which only holds after the fix. Measured before changing them:

| | before bump | after bump | round-trips |
|---|---|---|---|
| `list[path]` WINDOWS | `['\a', '\b']` | `['\\a', '\\b']` | now `True` |

Nothing regressed; the bump closed a silent-corruption path those two tests had frozen.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets` — clean
- Full suite: **5795 passed, 24 skipped, 3 xfailed**, coverage 94.25% against the 94% gate. The 3 xfails are pre-existing and unrelated; no `xfail_strict` test flipped, so nothing in the suite had recorded these fixes as known gaps.
- `black --check`, `ruff check`, `mypy` — clean
- `scripts/check_third_party_licenses.sh` in verify mode: `THIRD-PARTY-LICENSES.txt is up to date`

Unverified: the Windows helper-runner change (#369), for the reason given above. Windows CI on this PR exercises the bindings on Windows but not that helper's reader path.

## Known gap, not addressed here

Review flagged that `PyFormatString::__repr__` (`rust-bindings/src/expr/format_string.rs`) interpolates `self.inner.raw()` into a double-quoted literal with no escaping at all. Reproduced:

| raw | `repr(FormatString(raw))` | parses as Python? |
|---|---|---|
| `hello "world"` | `FormatString("hello "world"")` | SyntaxError: invalid syntax |
| `C:\a` | `FormatString("C:\a")` | parses — as BEL |
| `a\nb` | literal newline mid-repr | SyntaxError: unterminated string literal |

`ExprValue.__repr__` handles all three correctly on this branch, so the two `repr` implementations in the bindings now disagree on whether their output round-trips. It matters because `raw()` is template-derived text that reaches log lines and exception messages.

Deliberately not fixed in this PR. It is pre-existing on mainline (this diff's only hunks in that file are the `validate_expressions` doc comment and call site), and the natural fix is not currently available: the escaping writer #374 added is crate-private, `pub(crate) mod py_escape` / `pub(crate) fn write_py_string_literal`, so the bindings crate cannot route through it. Closing it needs openjd-rs to export the writer or a bare-string `repr_python` helper first, then a follow-up here.
