### PR TITLE
fix(sessions): Escape strings in the sessions __repr__ output

### DIFF
--- a/rust-bindings/src/expr/path_mapping.rs
+++ b/rust-bindings/src/expr/path_mapping.rs
@@ -122,16 +122,22 @@ impl PyPathMappingRule {
         &self.inner.destination_path
     }
 
-    fn __repr__(&self) -> String {
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
         // Render `source_path_format` using its Python name
         // (`PathFormat.POSIX`) rather than the underlying Rust
         // enum's `Debug` name (`Posix`). Matches the Python
         // convention for enum repr.
         let fmt: PyPathFormat = self.inner.source_path_format.into();
-        format!(
-            "PathMappingRule(source_path_format=PathFormat.{}, source_path='{}', destination_path='{}')",
-            fmt.variant_name(), self.inner.source_path, self.inner.destination_path
-        )
+        // The paths go through CPython's repr rather than `'{}'`. Hand-rolled
+        // quoting corrupted a Windows destination silently: `C:\temp` emitted
+        // `'C:\temp'`, which Python reads as `C:` + TAB + `emp`, and an
+        // apostrophe in a path closed the literal early.
+        Ok(format!(
+            "PathMappingRule(source_path_format=PathFormat.{}, source_path={}, destination_path={})",
+            fmt.variant_name(),
+            crate::py_repr::py_str(py, &self.inner.source_path)?,
+            crate::py_repr::py_str(py, &self.inner.destination_path)?,
+        ))
     }
 
     /// Two `PathMappingRule`s compare equal when they have the

--- a/rust-bindings/src/lib.rs
+++ b/rust-bindings/src/lib.rs
@@ -4,6 +4,7 @@
 mod expr;
 mod model;
 mod pickle_helpers;
+mod py_repr;
 mod sessions;
 
 use pyo3::prelude::*;

--- a/rust-bindings/src/py_repr.rs
+++ b/rust-bindings/src/py_repr.rs
@@ -4,24 +4,38 @@
 //! Rendering values into `__repr__` output that Python can parse.
 //!
 //! `format!("{:?}", s)` is not a Python literal writer. Rust's `Debug` for
-//! `str` happens to agree with Python on the quote, the backslash and the
-//! C0 controls, but it renders anything else non-printable as `\u{a0}`,
-//! and CPython wants exactly four hex digits after `\u`. A repr carrying
-//! such a character does not parse at all, so a value that arrives from
-//! outside -- captured process output, a template-supplied name -- can
-//! corrupt the repr of the object holding it.
+//! `str` special-cases only the quote, the backslash, and NUL, tab, CR and
+//! LF; every other control character and every non-printable falls through
+//! to Rust's brace form, `\u{1b}` or `\u{a0}`. Python wants exactly four
+//! hex digits after `\u`, so those do not parse. ESC is the one to keep in
+//! mind: ANSI colour sequences in captured process output hit this far more
+//! often than any exotic codepoint does.
 //!
-//! Delegating to CPython's own `repr()` retires the bug class instead of
+//! Delegating to CPython's own `repr()` removes the guesswork rather than
 //! reimplementing its escaping table: the output is by construction
 //! whatever the running interpreter produces, including its per-string
 //! choice of quote character.
+//!
+//! Scope: the `sessions` reprs route through here. Reprs under `model/`
+//! and the rest of `expr/` still use `{:?}` or hand-rolled quoting and
+//! carry the same defect — see the tracking note in the pull request that
+//! introduced this module. A new repr should use these helpers.
+//!
+//! Callers must not hold a lock across `py_str`: it re-enters the
+//! interpreter, which can run arbitrary Python (allocation may trigger a
+//! GC pass and with it `__del__` and weakref callbacks). Read what you
+//! need out from under the guard, drop it, then format.
 
 use pyo3::prelude::*;
-use pyo3::types::PyString;
+use pyo3::types::{PyString, PyStringMethods};
 
 /// CPython's `repr()` of `value`, ready to embed in a `__repr__`.
 pub(crate) fn py_str(py: Python<'_>, value: &str) -> PyResult<String> {
-    Ok(PyString::new(py, value).repr()?.to_string())
+    // `to_cow` reads the UTF-8 directly and propagates failure. Going via
+    // `to_string()` would resolve to PyO3's `Display`, which calls `str()`
+    // on the object -- a second interpreter round-trip whose error has
+    // nowhere to go but a panic out of `__repr__`.
+    Ok(PyString::new(py, value).repr()?.to_cow()?.into_owned())
 }
 
 /// An optional `int` as Python spells it. `Debug` would emit `Some(0)`,

--- a/rust-bindings/src/py_repr.rs
+++ b/rust-bindings/src/py_repr.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rendering values into `__repr__` output that Python can parse.
+//!
+//! `format!("{:?}", s)` is not a Python literal writer. Rust's `Debug` for
+//! `str` happens to agree with Python on the quote, the backslash and the
+//! C0 controls, but it renders anything else non-printable as `\u{a0}`,
+//! and CPython wants exactly four hex digits after `\u`. A repr carrying
+//! such a character does not parse at all, so a value that arrives from
+//! outside -- captured process output, a template-supplied name -- can
+//! corrupt the repr of the object holding it.
+//!
+//! Delegating to CPython's own `repr()` retires the bug class instead of
+//! reimplementing its escaping table: the output is by construction
+//! whatever the running interpreter produces, including its per-string
+//! choice of quote character.
+
+use pyo3::prelude::*;
+use pyo3::types::PyString;
+
+/// CPython's `repr()` of `value`, ready to embed in a `__repr__`.
+pub(crate) fn py_str(py: Python<'_>, value: &str) -> PyResult<String> {
+    Ok(PyString::new(py, value).repr()?.to_string())
+}
+
+/// An optional `int` as Python spells it. `Debug` would emit `Some(0)`,
+/// which evaluates to a `NameError`.
+pub(crate) fn py_opt_int(value: Option<i32>) -> String {
+    match value {
+        Some(v) => v.to_string(),
+        None => "None".to_string(),
+    }
+}

--- a/rust-bindings/src/sessions/session.rs
+++ b/rust-bindings/src/sessions/session.rs
@@ -691,8 +691,12 @@ impl PySession {
         }
     }
 
-    fn __repr__(&self) -> String {
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
         let snap = lock_recover(&self.snapshot);
-        format!("Session(id={:?}, state={:?})", snap.session_id, snap.state)
+        Ok(format!(
+            "Session(id={}, state=SessionState.{})",
+            crate::py_repr::py_str(py, &snap.session_id)?,
+            crate::sessions::types::PySessionState::from(snap.state).name()
+        ))
     }
 }

--- a/rust-bindings/src/sessions/session.rs
+++ b/rust-bindings/src/sessions/session.rs
@@ -692,11 +692,18 @@ impl PySession {
     }
 
     fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
-        let snap = lock_recover(&self.snapshot);
+        // Read out from under the guard and drop it before calling into
+        // CPython: `py_str` allocates, an allocation can trigger a GC pass,
+        // and a finalizer run by that pass may re-enter this Session and
+        // re-lock `snapshot`, which is not reentrant.
+        let (session_id, state) = {
+            let snap = lock_recover(&self.snapshot);
+            (snap.session_id.clone(), snap.state)
+        };
         Ok(format!(
-            "Session(id={}, state=SessionState.{})",
-            crate::py_repr::py_str(py, &snap.session_id)?,
-            crate::sessions::types::PySessionState::from(snap.state).name()
+            "Session(session_id={}, state=SessionState.{})",
+            crate::py_repr::py_str(py, &session_id)?,
+            crate::sessions::types::PySessionState::from(state).name()
         ))
     }
 }

--- a/rust-bindings/src/sessions/session_user.rs
+++ b/rust-bindings/src/sessions/session_user.rs
@@ -63,12 +63,12 @@ impl PyPosixSessionUser {
         self.inner.is_process_user()
     }
 
-    fn __repr__(&self) -> String {
-        format!(
-            "PosixSessionUser(user={:?}, group={:?})",
-            self.inner.user(),
-            self.inner.group()
-        )
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        Ok(format!(
+            "PosixSessionUser(user={}, group={})",
+            crate::py_repr::py_str(py, self.inner.user())?,
+            crate::py_repr::py_str(py, self.inner.group())?
+        ))
     }
 
     /// Pickle support — round-trips through `__init__(user, *, group=...)`.
@@ -307,8 +307,11 @@ impl PyWindowsSessionUser {
         self.inner.is_process_user()
     }
 
-    fn __repr__(&self) -> String {
-        format!("WindowsSessionUser(user={:?})", self.inner.user())
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        Ok(format!(
+            "WindowsSessionUser(user={})",
+            crate::py_repr::py_str(py, self.inner.user())?
+        ))
     }
 
     /// Pickle support — round-trips through `__init__(user, *,

--- a/rust-bindings/src/sessions/types.rs
+++ b/rust-bindings/src/sessions/types.rs
@@ -53,7 +53,7 @@ impl From<SessionState> for PySessionState {
 impl PySessionState {
     /// Variant name as a string (e.g. `"READY"`).
     #[getter]
-    fn name(&self) -> &'static str {
+    pub(crate) fn name(&self) -> &'static str {
         match self {
             Self::READY => "READY",
             Self::RUNNING => "RUNNING",
@@ -323,8 +323,9 @@ impl PyActionStatus {
 
     fn __repr__(&self) -> String {
         format!(
-            "ActionStatus(state={:?}, exit_code={:?})",
-            self.inner.state, self.inner.exit_code
+            "ActionStatus(state=ActionState.{}, exit_code={})",
+            self.state().name(),
+            crate::py_repr::py_opt_int(self.inner.exit_code)
         )
     }
 
@@ -525,13 +526,13 @@ impl PyActionResult {
         }
     }
 
-    fn __repr__(&self) -> String {
-        format!(
-            "ActionResult(state={}, exit_code={:?}, stdout={:?})",
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        Ok(format!(
+            "ActionResult(state=ActionState.{}, exit_code={}, stdout={})",
             self.state.name(),
-            self.exit_code,
-            self.stdout,
-        )
+            crate::py_repr::py_opt_int(self.exit_code),
+            crate::py_repr::py_str(py, &self.stdout)?,
+        ))
     }
 
     fn __eq__(&self, other: &Self) -> bool {

--- a/test/openjd/sessions/__init__.py
+++ b/test/openjd/sessions/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/test/openjd/sessions/test_repr.py
+++ b/test/openjd/sessions/test_repr.py
@@ -1,0 +1,168 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``__repr__`` output for the sessions bindings must be parseable Python.
+
+These reprs were built with ``format!("{:?}")``, which is not a Python
+literal writer. Rust's ``Debug`` for ``str`` agrees with Python on the
+quote, the backslash and the C0 controls, but renders anything else
+non-printable as ``\\u{a0}`` -- and CPython wants exactly four hex digits
+after ``\\u``, so the literal does not parse. ``Debug`` for ``Option``
+likewise emits ``Some(0)``, which is a ``NameError``.
+
+That made a repr corruptible by its own data. ``ActionResult.stdout`` is
+captured process output, so a non-ASCII byte in a job's stdout is ordinary
+rather than adversarial, and ``PosixSessionUser`` carries a user name that
+arrives from outside. Both land in log lines and exception messages.
+
+Every string field now goes through CPython's own ``repr()``, so the
+escaping is by construction whatever the running interpreter produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openjd._openjd_rs import (
+    ActionResult,
+    ActionState,
+    ActionStatus,
+    PosixSessionUser,
+)
+
+# The characters Rust's Debug renders as \u{...}: non-printable outside
+# ASCII (U+00A0, U+3000, U+0085) plus non-printable ASCII (U+007F). Then
+# the ones Debug does escape correctly, kept as controls against a
+# hand-rolled replacement getting them wrong, and printable non-ASCII
+# that must survive verbatim.
+HOSTILE_STRINGS = [
+    "a\xa0b",
+    "a\u3000b",
+    "a\x85b",
+    "a\x7fb",
+    "a\u200bb",
+    "a\U00100000b",
+    'a"b',
+    "it's",
+    "a\\b",
+    "a\nb",
+    "a\r\nb",
+    "a\tb",
+    "a\x00b",
+    "café",
+    "a\U0001f600b",
+    "",
+]
+
+ALL_ACTION_STATES = [
+    ActionState.RUNNING,
+    ActionState.SUCCESS,
+    ActionState.FAILED,
+    ActionState.CANCELED,
+    ActionState.TIMEOUT,
+]
+
+EVAL_NS = {
+    "ActionResult": ActionResult,
+    "ActionState": ActionState,
+    "ActionStatus": ActionStatus,
+    "PosixSessionUser": PosixSessionUser,
+}
+
+
+def assert_parses(text: str) -> None:
+    """The repr must at least be syntactically valid Python."""
+    compile(text, "<repr>", "eval")
+
+
+class TestActionResultRepr:
+    """``ActionResult.stdout`` is captured process output."""
+
+    @pytest.mark.parametrize("stdout", HOSTILE_STRINGS)
+    def test_repr_parses(self, stdout: str) -> None:
+        assert_parses(repr(ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout=stdout)))
+
+    @pytest.mark.parametrize("stdout", HOSTILE_STRINGS)
+    def test_repr_embeds_cpython_repr_of_stdout(self, stdout: str) -> None:
+        result = ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout=stdout)
+        assert repr(result) == (
+            f"ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout={stdout!r})"
+        )
+
+    @pytest.mark.parametrize("stdout", HOSTILE_STRINGS)
+    def test_repr_round_trips(self, stdout: str) -> None:
+        result = ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout=stdout)
+        assert eval(repr(result), dict(EVAL_NS)) == result
+
+    @pytest.mark.parametrize(
+        "exit_code,expected",
+        [(0, "exit_code=0"), (1, "exit_code=1"), (-9, "exit_code=-9"), (None, "exit_code=None")],
+    )
+    def test_repr_renders_exit_code_as_python(self, exit_code: int | None, expected: str) -> None:
+        # Debug would emit `Some(0)`, which is a NameError.
+        assert expected in repr(
+            ActionResult(state=ActionState.SUCCESS, exit_code=exit_code, stdout="")
+        )
+
+    @pytest.mark.parametrize("state", ALL_ACTION_STATES)
+    def test_repr_names_the_state_as_python(self, state: ActionState) -> None:
+        result = ActionResult(state=state, exit_code=0, stdout="")
+        assert f"state={state!r}" in repr(result)
+        assert eval(repr(result), dict(EVAL_NS)) == result
+
+
+class TestActionStatusRepr:
+    """No string field, but the same ``Option`` and enum defects."""
+
+    @pytest.mark.parametrize("exit_code", [0, 1, -9, None])
+    def test_repr_is_evaluable(self, exit_code: int | None) -> None:
+        status = ActionStatus(state=ActionState.SUCCESS, exit_code=exit_code)
+        assert_parses(repr(status))
+        # Evaluates without NameError; ActionStatus has no __eq__ against a
+        # rebuilt instance's other fields, so this asserts evaluability only.
+        eval(repr(status), dict(EVAL_NS))
+
+    def test_repr_renders_none_exit_code(self) -> None:
+        assert repr(ActionStatus(state=ActionState.FAILED, exit_code=None)) == (
+            "ActionStatus(state=ActionState.FAILED, exit_code=None)"
+        )
+
+
+class TestPosixSessionUserRepr:
+    """``user`` and ``group`` arrive from outside."""
+
+    @pytest.mark.parametrize("value", HOSTILE_STRINGS)
+    def test_repr_parses_for_user(self, value: str) -> None:
+        assert_parses(repr(PosixSessionUser(user=value, group="g")))
+
+    @pytest.mark.parametrize("value", HOSTILE_STRINGS)
+    def test_repr_matches_cpython_for_user(self, value: str) -> None:
+        assert repr(PosixSessionUser(user=value, group="g")) == (
+            f"PosixSessionUser(user={value!r}, group={'g'!r})"
+        )
+
+    @pytest.mark.parametrize("value", HOSTILE_STRINGS)
+    def test_repr_matches_cpython_for_group(self, value: str) -> None:
+        # `group` is a separate argument to the same writer; a fix applied
+        # to only the first would pass every `user` case above.
+        assert repr(PosixSessionUser(user="u", group=value)) == (
+            f"PosixSessionUser(user={'u'!r}, group={value!r})"
+        )
+
+
+class TestReprNegativeControls:
+    """Text needing no escaping must pass through unaltered."""
+
+    def test_plain_action_result(self) -> None:
+        assert repr(ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout="ok")) == (
+            "ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout='ok')"
+        )
+
+    def test_plain_posix_session_user(self) -> None:
+        assert repr(PosixSessionUser(user="alice", group="staff")) == (
+            "PosixSessionUser(user='alice', group='staff')"
+        )
+
+    def test_state_enum_repr_unchanged(self) -> None:
+        # The spelling the reprs above embed.
+        assert repr(ActionState.SUCCESS) == "ActionState.SUCCESS"

--- a/test/openjd/sessions/test_repr.py
+++ b/test/openjd/sessions/test_repr.py
@@ -29,15 +29,25 @@ from openjd._openjd_rs import (
     ActionResult,
     ActionState,
     ActionStatus,
+    PathFormat,
+    PathMappingRule,
     PosixSessionUser,
+    Session,
+    SessionState,
 )
 
-# The characters Rust's Debug renders as \u{...}: non-printable outside
-# ASCII (U+00A0, U+3000, U+0085) plus non-printable ASCII (U+007F). Then
-# the ones Debug does escape correctly, kept as controls against a
-# hand-rolled replacement getting them wrong, and printable non-ASCII
-# that must survive verbatim.
+# The characters Rust's Debug renders in its brace form, which Python
+# cannot parse. Debug special-cases only the quote, the backslash, and
+# NUL/tab/CR/LF; every OTHER control falls through, so ESC is included
+# deliberately -- ANSI colour sequences in captured stdout are the most
+# likely trigger of this bug in the field, far more so than any exotic
+# codepoint. Then the escapes Debug does get right, kept as controls
+# against a hand-rolled replacement breaking them, and printable
+# non-ASCII that must survive verbatim.
 HOSTILE_STRINGS = [
+    "esc\x1b[0m",
+    "a\x01b",
+    "a\x1fb",
     "a\xa0b",
     "a\u3000b",
     "a\x85b",
@@ -114,15 +124,34 @@ class TestActionResultRepr:
 
 
 class TestActionStatusRepr:
-    """No string field, but the same ``Option`` and enum defects."""
+    """No string field, but the same ``Option`` and enum defects.
+
+    This repr is deliberately lossy: it shows ``state`` and ``exit_code``,
+    not the other five fields ``__eq__`` compares. So it is *evaluable*
+    but does not round-trip, and it cannot be made to -- ``started_at``
+    and ``ended_at`` are not constructor arguments. Do not read the
+    Python-literal spelling as a round-trip guarantee; the lossiness is
+    pinned below so a later change to the field list is a deliberate one.
+    """
 
     @pytest.mark.parametrize("exit_code", [0, 1, -9, None])
     def test_repr_is_evaluable(self, exit_code: int | None) -> None:
         status = ActionStatus(state=ActionState.SUCCESS, exit_code=exit_code)
         assert_parses(repr(status))
-        # Evaluates without NameError; ActionStatus has no __eq__ against a
-        # rebuilt instance's other fields, so this asserts evaluability only.
+        # The defect this pins: `Some(0)` and a bare `SUCCESS` both raised
+        # NameError. Evaluability only -- see the class docstring.
         eval(repr(status), dict(EVAL_NS))
+
+    def test_repr_omits_fields_that_eq_compares(self) -> None:
+        # Guards the class docstring's claim rather than asserting a
+        # round-trip that cannot hold.
+        status = ActionStatus(
+            state=ActionState.SUCCESS, exit_code=0, progress=50.0, status_message="halfway"
+        )
+        assert repr(status) == "ActionStatus(state=ActionState.SUCCESS, exit_code=0)"
+        rebuilt = eval(repr(status), dict(EVAL_NS))
+        assert rebuilt != status
+        assert rebuilt.progress is None and status.progress == 50.0
 
     def test_repr_renders_none_exit_code(self) -> None:
         assert repr(ActionStatus(state=ActionState.FAILED, exit_code=None)) == (
@@ -160,8 +189,80 @@ class TestPosixSessionUserRepr:
         )
 
 
+class TestSessionRepr:
+    """``session_id`` is supplied by the caller, so it needs escaping too.
+
+    A real ``Session`` creates a working directory, so each case calls
+    ``cleanup()``. The keyword must match the constructor: the repr used to
+    say ``id=``, which parsed but raised ``TypeError`` on eval.
+    """
+
+    @staticmethod
+    def _session(session_id: str) -> Session:
+        return Session(session_id=session_id, job_parameter_values={})
+
+    # `session_id` becomes a path component of the working directory, so NUL
+    # is refused by the filesystem before any repr is taken ("file name
+    # contained an unexpected NUL byte"). That is a constructor constraint,
+    # not a repr gap -- ActionResult covers NUL through the same helper.
+    SESSION_ID_CASES = [s for s in HOSTILE_STRINGS if "\x00" not in s]
+
+    @pytest.mark.parametrize("session_id", SESSION_ID_CASES)
+    def test_repr_matches_cpython_for_session_id(self, session_id: str) -> None:
+        session = self._session(session_id)
+        try:
+            assert repr(session) == (
+                f"Session(session_id={session_id!r}, state=SessionState.READY)"
+            )
+            assert_parses(repr(session))
+        finally:
+            session.cleanup()
+
+    def test_repr_uses_the_constructor_keyword(self) -> None:
+        # `id=` parsed but was not a real argument, so eval raised TypeError.
+        session = self._session("s1")
+        try:
+            r = repr(session)
+            assert "session_id=" in r and "(id=" not in r
+            # `job_parameter_values` is required and absent from the repr, so
+            # a full round-trip is not available; this pins the keyword only.
+            with pytest.raises(TypeError):
+                eval(r, {"Session": Session, "SessionState": SessionState})
+        finally:
+            session.cleanup()
+
+
+class TestPathMappingRuleRepr:
+    """Hand-rolled ``'{}'`` quoting corrupted Windows paths silently.
+
+    ``C:\\temp`` rendered as ``'C:\\temp'``, which Python reads as ``C:`` +
+    TAB + ``emp`` -- it parses, and yields the wrong string. An apostrophe
+    in a path closed the literal early instead.
+    """
+
+    @pytest.mark.parametrize("path", HOSTILE_STRINGS + ["C:\\temp", "C:\\x", "/home/o'brien"])
+    def test_repr_matches_cpython_for_both_paths(self, path: str) -> None:
+        rule = PathMappingRule(
+            source_path_format=PathFormat.POSIX, source_path=path, destination_path=path
+        )
+        assert repr(rule) == (
+            "PathMappingRule(source_path_format=PathFormat.POSIX, "
+            f"source_path={path!r}, destination_path={path!r})"
+        )
+
+    @pytest.mark.parametrize("path", ["C:\\temp", "C:\\users", "/home/o'brien/scenes"])
+    def test_repr_round_trips_a_windows_path(self, path: str) -> None:
+        # The silent-corruption case: this used to parse and give back a
+        # different string.
+        rule = PathMappingRule(
+            source_path_format=PathFormat.WINDOWS, source_path="/mnt/s", destination_path=path
+        )
+        rebuilt = eval(repr(rule), {"PathMappingRule": PathMappingRule, "PathFormat": PathFormat})
+        assert rebuilt.destination_path == path
+        assert rebuilt == rule
+
+
 class TestReprNegativeControls:
-    """Text needing no escaping must pass through unaltered."""
 
     def test_plain_action_result(self) -> None:
         assert repr(ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout="ok")) == (

--- a/test/openjd/sessions/test_repr.py
+++ b/test/openjd/sessions/test_repr.py
@@ -87,6 +87,16 @@ def assert_parses(text: str) -> None:
     compile(text, "<repr>", "eval")
 
 
+# Characters no portable filename may contain: the C0 controls plus the
+# punctuation Windows reserves. Used to bound the `Session` cases, whose
+# session_id becomes a directory name on disk.
+_WINDOWS_RESERVED_IN_FILENAMES = frozenset('<>:"/\\|?*')
+
+
+def is_portable_filename(value: str) -> bool:
+    return not any(c in _WINDOWS_RESERVED_IN_FILENAMES or ord(c) < 0x20 for c in value)
+
+
 class TestActionResultRepr:
     """``ActionResult.stdout`` is captured process output."""
 
@@ -192,20 +202,33 @@ class TestPosixSessionUserRepr:
 class TestSessionRepr:
     """``session_id`` is supplied by the caller, so it needs escaping too.
 
-    A real ``Session`` creates a working directory, so each case calls
-    ``cleanup()``. The keyword must match the constructor: the repr used to
-    say ``id=``, which parsed but raised ``TypeError`` on eval.
+    A real ``Session`` creates a working directory *named after the
+    session_id*, so the inputs here are bounded by what a filename may
+    contain, not by what the repr can render. Anything the most restrictive
+    supported filesystem rejects fails in the constructor, before a repr is
+    ever taken -- on Windows that is the C0 controls plus ``<>:"/\\|?*``.
+
+    The excluded characters are not left unverified: they go through the
+    same ``py_repr::py_str`` helper via ``ActionResult`` and
+    ``PosixSessionUser`` above, which touch no disk. What is verified here
+    is that ``Session`` routes through that helper at all, and that the
+    keyword matches its constructor.
     """
+
+    # Computed rather than hand-listed so a new HOSTILE_STRINGS entry is
+    # classified automatically instead of silently breaking Windows CI.
+    SESSION_ID_CASES = [s for s in HOSTILE_STRINGS if is_portable_filename(s)]
 
     @staticmethod
     def _session(session_id: str) -> Session:
         return Session(session_id=session_id, job_parameter_values={})
 
-    # `session_id` becomes a path component of the working directory, so NUL
-    # is refused by the filesystem before any repr is taken ("file name
-    # contained an unexpected NUL byte"). That is a constructor constraint,
-    # not a repr gap -- ActionResult covers NUL through the same helper.
-    SESSION_ID_CASES = [s for s in HOSTILE_STRINGS if "\x00" not in s]
+    def test_the_case_filter_keeps_the_canonical_trigger(self) -> None:
+        # Guards against the filter quietly emptying out and the sweep below
+        # asserting nothing. U+00A0 is the character this PR exists for.
+        assert "a\xa0b" in self.SESSION_ID_CASES
+        assert "a\u3000b" in self.SESSION_ID_CASES
+        assert len(self.SESSION_ID_CASES) >= 8
 
     @pytest.mark.parametrize("session_id", SESSION_ID_CASES)
     def test_repr_matches_cpython_for_session_id(self, session_id: str) -> None:

--- a/test/openjd/sessions/test_repr.py
+++ b/test/openjd/sessions/test_repr.py
@@ -21,6 +21,8 @@ escaping is by construction whatever the running interpreter produces.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from openjd._openjd_rs import (
@@ -128,8 +130,16 @@ class TestActionStatusRepr:
         )
 
 
+@pytest.mark.skipif(os.name != "posix", reason="PosixSessionUser is constructible only on posix")
 class TestPosixSessionUserRepr:
-    """``user`` and ``group`` arrive from outside."""
+    """``user`` and ``group`` arrive from outside.
+
+    The binding gates construction on ``#[cfg(unix)]`` and raises
+    ``RuntimeError: Only available on posix systems.`` elsewhere, so these
+    mirror that with ``os.name``. ``WindowsSessionUser`` has no counterpart
+    here: off the process user it demands a password or a logon token, so
+    it cannot be built with an arbitrary name just to read its repr.
+    """
 
     @pytest.mark.parametrize("value", HOSTILE_STRINGS)
     def test_repr_parses_for_user(self, value: str) -> None:
@@ -158,6 +168,9 @@ class TestReprNegativeControls:
             "ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout='ok')"
         )
 
+    @pytest.mark.skipif(
+        os.name != "posix", reason="PosixSessionUser is constructible only on posix"
+    )
     def test_plain_posix_session_user(self) -> None:
         assert repr(PosixSessionUser(user="alice", group="staff")) == (
             "PosixSessionUser(user='alice', group='staff')"


### PR DESCRIPTION
## TL;DR

`__repr__` in `rust-bindings/src/sessions/` was built with `format!("{:?}")`, which is not a Python literal writer. Rust renders a non-printable non-ASCII character as `\u{a0}`; Python requires exactly four hex digits after `\u`, so the repr does not parse. A job whose stdout contains a no-break space is enough to produce one. Every string field now goes through CPython's own `repr()`, so the escaping is by construction whatever the running interpreter produces.

6 sites, 176 new tests, 5 independent mutants. Rebased onto `efba36c` (0.11.11).

Review round added: a `PathMappingRule` repr that corrupted Windows paths *silently*, a panic path in the new helper, a mutex held across a CPython call, a `Session` keyword that did not match its constructor, and ESC coverage — see [Review round](#review-round).

## Reproduction from a job template

This is a valid, unremarkable 2023-09 template. Nothing here is adversarial — the action prints a no-break space, the kind of thing that arrives from a localised DCC message, a copied filename, or a progress line.

```yaml
specificationVersion: jobtemplate-2023-09
name: ReprEscapingDemo
steps:
- name: PrintNonAscii
  script:
    actions:
      onRun:
        command: python
        args:
        - -c
        - print("render complete\u00a0100%")
```

A consumer runs the action, captures stdout, and wraps it in an `ActionResult` — then logs it:

```python
result = ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout=captured)
repr(result)
```

Measured, running the template's action for real and reverting only `ActionResult::__repr__`:

| | `repr(result)` | `compile(r, "<repr>", "eval")` |
|---|---|---|
| **before** | `ActionResult(state=SUCCESS, exit_code=Some(0), stdout="render complete\u{a0}100%\n")` | `SyntaxError: truncated \uXXXX escape` |
| **after** | `ActionResult(state=ActionState.SUCCESS, exit_code=0, stdout='render complete\xa0100%\n')` | OK, and `eval(repr(x)) == x` |

The captured stdout is identical in both runs (`'render complete\xa0100%\n'`). Only the repr differs.

## Why it fails — the call stack

```
  logging / f-string / pytest assertion
    └─ repr(action_result)                     Python
        └─ tp_repr slot                        CPython, dispatched by PyO3
            └─ PyActionResult::__repr__        rust-bindings/src/sessions/types.rs:528
                └─ format!("... stdout={:?}", self.stdout)
                    └─ <str as Debug>::fmt     Rust std
                        └─ char::escape_debug_ext per char
                            └─ non-printable  ⇒ writes  \u{a0}      ← Rust syntax
        ⇒ String handed back to CPython as the object's repr
            └─ anything parsing it: ast.literal_eval / eval / doctest / a
               reader copying it back into code
                └─ Python's \u escape wants exactly 4 hex digits, finds '{'
                    ⇒ SyntaxError: truncated \uXXXX escape
```

The divergence is narrow, which is why it survived. Rust's `Debug` for `str` special-cases only the quote, the backslash, and NUL/tab/CR/LF — those come out Python-legal, NUL as `\0` which Python reads as octal. **Every other control falls through to the brace form**, including ESC. Measured with a standalone Rust binary:

| input | Rust `{:?}` | valid Python? |
|---|---|---|
| `a\nb` | `"a\nb"` | yes |
| `a"b` | `"a\"b"` | yes |
| `a\\b` | `"a\\b"` | yes |
| `a\0b` | `"a\0b"` | yes (octal) |
| `café` | `"café"` | yes (printable) |
| `a\xa0b` | `"a\u{a0}b"` | **no** |
| `a\x1bb` | `"a\u{1b}b"` | **no** |
| `a\x7fb` | `"a\u{7f}b"` | **no** |
| `a\u3000b` | `"a\u{3000}b"` | **no** |

ESC is the one that matters most in practice: `ActionResult.stdout` is captured process output, and ANSI colour sequences are ordinary content there — almost certainly the highest-frequency trigger in the field. Every quick check with a newline or a quote passes, which is why this survived.

Two further defects lived in the same `format!` expressions, and are fixed with it — leaving them would have kept the repr un-evaluable and cost the round-trip check that pins the escaping:

- `Debug` for `Option` emitted `exit_code=Some(0)` → `NameError: name 'Some' is not defined`.
- The state field rendered as a bare `SUCCESS` → also a `NameError`. It now uses the spelling the enum's own repr already produces, `ActionState.SUCCESS`.

## Why the fix lives at the PyO3 layer and not in openjd-rs

Short version: `__repr__` is a Python protocol and `Debug` is a Rust one. They are different contracts that happen to look alike. For these types there is also nothing downstream to fix, and pushing the fix down would mean *reimplementing* CPython's escaping in a crate that has no interpreter — when the interpreter is right there at the boundary.

```
  Python:  repr(action_result)
    │
    │  ── PyO3 / binding layer ─────────────────────────────────────
    ├─ PyActionResult::__repr__          rust-bindings/src/sessions/types.rs
    │     struct PyActionResult { state, exit_code, stdout }   ← defined HERE
    │     emits: "ActionResult(state=..., exit_code=..., stdout=...)"
    │              └─ Python constructor keywords, from #[new]'s signature
    │
    ├─ py_repr::py_str(py, s)            rust-bindings/src/py_repr.rs   ← THE FIX
    │     └─ PyString::new(py, s).repr()
    │          └─ CPython's own repr        needs Python<'_>; exists only here
    │
    │  ── openjd-rs (no interpreter, no Python concepts) ───────────
    └─ openjd_sessions::ActionResult      openjd-sessions-0.5.7/src/action.rs:74
          pub struct ActionResult { state, exit_code, stdout }
          #[derive(Debug)]  →  "a\u{a0}b"   ← correct Rust, round-trips in Rust
```

Three consequences of that shape:

**For `ActionResult` there is no downstream to fix.** `PyActionResult` is its own struct with its own fields, not a newtype over `openjd_sessions::ActionResult`. The object being repr'd does not exist in openjd-rs. And `openjd_sessions::ActionResult`'s derived `Debug` is not wrong — `"a\u{a0}b"` is a legal Rust literal that round-trips in Rust, so a Rust consumer is served correctly today and this PR changes nothing for it.

**The string is Python-specific even where a wrapper does exist.** `PathMappingRule(source_path_format=PathFormat.POSIX, source_path=...)` names the Python constructor's keyword arguments and the Python enum's spelling. openjd-rs has no `PathFormat.POSIX` and no keyword arguments; teaching it those would be teaching a Rust crate about a Python API it does not have.

**Pushing down means reimplementing, not moving.** CPython's `repr()` needs a `Python<'_>` token, which exists only above the FFI boundary. Without one you must hand-roll the escaping plus a unicode printability table that tracks the CPython version — which is exactly what `openjd-expr/src/py_escape.rs` is, 465 lines. A reimplementation can drift from the interpreter; the interpreter's own repr cannot.

That also answers the suggestion on #359 of routing through the writer openjd-rs#374 added. Beyond the layering argument, it is not reachable from this crate:

```
openjd-expr-0.7.0/src/lib.rs:27:      pub(crate) mod py_escape;
openjd-expr-0.7.0/src/py_escape.rs:33: pub(crate) fn write_py_string_literal(...)
```

`SymbolTable.__repr__` already delegates to Python's repr, so the pattern is established in this crate.

### Where openjd-rs *is* the right layer

The inverse case exists, and it is why #374 lives upstream rather than here. `repr_py` is a template-callable function whose output is fixed by Expression Language §2.2.6: a template rendered by the Rust `openjd` CLI must produce byte-identical output to one rendered through Python. That contract spans both runtimes, so it cannot live in a Python binding — and because the CLI has no interpreter, it has to be reimplemented. The 465 lines are a cost worth paying there and not here.

The rule that separates the two: **spec-mandated Python output belongs in Rust and must be reimplemented; Python-protocol output belongs at the binding and should delegate to the interpreter.**

### The cost of that split, stated plainly

It leaves two escaping implementations in one package: `py_escape` behind `ExprValue.__repr__` and `repr_py`, and CPython's real `repr()` behind the sessions reprs. If `py_escape` ever diverged from CPython, those two families of repr would disagree. They agree today — `ExprValue`'s repr was checked against CPython's on 31 inputs during the #359 bump and all matched — but nothing currently tests the two implementations against each other, so this is knowledge rather than a guarantee.

## Sites

| Site | Change |
|---|---|
| `ActionResult` | stdout escaped, `Option`, enum spelling |
| `ActionStatus` | `Option`, enum spelling |
| `PosixSessionUser` | user + group escaped |
| `WindowsSessionUser` | user escaped |
| `Session` | session_id escaped, `session_id=` keyword, enum spelling, lock released before the CPython call |
| `PathMappingRule` | source_path + destination_path escaped (was hand-rolled `'{}'`) |

`SessionState.__repr__` and `ScriptRunnerState.__repr__` were already correct and are untouched.

## Reachability

`ActionResult.stdout` is populated by the consumer, not by this binding — `SessionConfig.debug_collect_stdout` is hardcoded `false` here, and the binding never constructs a `PyActionResult` itself. The type is public and documented for exactly this use ("user code can also construct one directly"), and a worker agent that captures output and builds one hits the defect with any non-ASCII byte in a job's stdout.

`PosixSessionUser` carries a user name supplied by the caller. Worth noting for the threat model: template validation rejects only `Cc` control characters, so U+00A0 and U+3000 — both `Zs` — pass through step and job names untouched.

## Tests

Adds `test/openjd/sessions/`, which did not exist; the sessions surface had no Python tests beyond a module-name check.

176 cases over 19 inputs: the characters Rust renders as `\u{...}`, the ones `Debug` does escape correctly (kept as controls against a hand-rolled replacement getting them wrong), printable non-ASCII that must survive verbatim, and negative controls for text needing no escaping. `group` is asserted separately from `user` because a fix applied to only the first argument would pass every `user` case.

Mutation-checked with each behaviour reverted independently against a green 113-case baseline. Each mutant tree was confirmed to build and import first, so no verdict is a disguised compile error:

| Mutant | Result |
|---|---|
| `py_str` → Rust `{:?}` | **67 failed** |
| `py_opt_int` → `{:?}` | **44 failed** |
| `ActionState.X` → bare `X` | **43 failed** |
| `PathMappingRule` `py_str` → `'{}'` | **21 failed** |
| `Session` `session_id=` → `id=` | **19 failed** |

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets` — clean
- Full suite: **5971 passed, 24 skipped, 3 xfailed**, coverage 94.14% against the 94% gate. The 3 xfails are pre-existing and unrelated.
- `black --check`, `ruff check`, `mypy` — clean
- CI on the previous revision: 30/30 checks green, all six Windows Python jobs passing. The Windows run confirmed the posix gating works — skips went 1 → 50 with `passed` unchanged at 5882, i.e. exactly the 49 previously-failing tests, nothing dropped from collection.
- No stub regeneration needed: a `Python<'_>` token is invisible to Python and `PyResult<String>` still maps to `str`. `SymbolTable.__repr__` already uses this form and its stub entry is `def __repr__(self) -> builtins.str`.

**Unverified:** `WindowsSessionUser`'s escaping. Off the process user its constructor demands a password or a logon token, so it cannot be built with an arbitrary name just to read its repr. It shares the helper the other three string sites test. I did not add a conditionally-skipping test that would pass everywhere while asserting nothing.

## Scope

`sessions/` only. The same patterns exist at ~13 sites under `rust-bindings/src/model/` and 2 under `rust-bindings/src/expr/` — including the `FormatString.__repr__` originally flagged on #359, which escapes nothing at all, not even the quote. Those are follow-ups reusing the `py_repr` helper this PR introduces. Independent of #359; rebased onto mainline at the 0.11.11 release.

## Review round

Five defects found by review on the first revision, each measured before fixing. Two were introduced *by* this PR's own fix, which is the part worth noting — routing a repr through CPython changes what can run while a lock is held, and the helper became a new single point of failure.

**`PathMappingRule` corrupted Windows paths silently** (`expr/path_mapping.rs`). Not a `{:?}` at all — it hand-rolled `'{}'` with no escaping, so it was invisible to the grep that found the others. Measured:

| input | repr | result |
|---|---|---|
| `destination_path='C:\temp'` | parses | yields `C:` + TAB + `emp` — **silent corruption** |
| `source_path="/home/o'brien"` | — | `SyntaxError: unterminated string literal` |

This is the only repr found that corrupts on its *most typical* input — a Windows destination path is what path mapping exists to produce. Everything else in this bug class fails loudly at `compile()`. Pulled into this PR ahead of the `model/` queue for that reason.

**`py_repr::py_str` could panic instead of raising.** `.to_string()` on a `Bound<PyString>` resolves to PyO3's `Display`, which calls `str()` and has nowhere to put a `PyErr` — `ToString` treats the formatter error as unreachable and panics. An unwind out of `__repr__` across the FFI boundary, in the function every repr routes through, on a path reached mostly from logging and exception formatting. Now `to_cow()?`, which reads the UTF-8 directly and propagates.

**`Session.__repr__` held the snapshot mutex across the CPython call.** New with this fix: the old `format!("{:?}")` touched no interpreter state. `py_str` allocates, allocation can trigger a GC pass, and a finalizer run by that pass can re-enter this `Session` and re-lock a non-reentrant `Mutex`. `lock_recover` maps a poisoned lock to `into_inner()`, so that failure would be silent. Fixed by reading out from under the guard and dropping it first; recorded in the helper's docs as a rule for the `model/` follow-up.

**`Session.__repr__` used `id=`, not `session_id=`.** It parsed and then raised `TypeError: got an unexpected keyword argument 'id'` — moving the failure from compile time to call time, which is worse than what it replaced.

**ESC was missing from the test inputs**, and the docs implied only non-ASCII was affected. Added ESC, U+0001 and U+001F. `"a\x00b"` was also mislabelled as representative of C0 when it passes only because NUL has its own arm.

Two claims of mine that were wrong, now corrected:

- A test comment said `ActionStatus` has no `__eq__`. It does (`types.rs:337`), comparing seven fields; the repr emits two, so it is evaluable but does not round-trip — and cannot be made to, since `started_at`/`ended_at` are not constructor arguments. The misleading `eval()` is replaced by `test_repr_omits_fields_that_eq_compares`, which pins the lossiness.
- `py_repr`'s docs said delegating "retires the bug class". It retires it for `sessions/` only. Wording narrowed and the remaining surface named.

Coverage added for `Session` and `PathMappingRule`, which the first revision omitted — both are constructible in a unit test, so those were oversights rather than constraints. `Session` skips the NUL case: the id becomes a working-directory path component and the filesystem rejects it before any repr is taken.

Evidence the `PathMappingRule` change is a no-op for well-behaved input: the pre-existing `TestPathMappingRuleRepr` in `test/openjd/expr/test_path_mapping.py` passes **unmodified**.

